### PR TITLE
fix(jellyfin): fix startup failure due to broken sed patches

### DIFF
--- a/jellyfin/CHANGELOG.md
+++ b/jellyfin/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 10.11.9 (27-04-2026)
+
+- Fix startup failure: JELLYFIN_WEB_DIR was incorrectly redirected to data
+  location instead of /usr/share/jellyfin/web, preventing the web UI from
+  loading
+- Fix LOCATION fallback: the null/empty check was setting LOCATION to itself
+  instead of /config due to sed substitution order
+
 ## 10.11.8 (26-04-2026)
 
 - Initial release based on Jellyfin 10.11.8

--- a/jellyfin/Dockerfile
+++ b/jellyfin/Dockerfile
@@ -17,10 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
-    sed -i "s|/usr/share/jellyfin|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-jellyfin/run
 
 COPY rootfs/ /

--- a/jellyfin/config.yaml
+++ b/jellyfin/config.yaml
@@ -100,5 +100,5 @@ schema:
 slug: jellyfin
 udev: true
 url: https://jellyfin.org
-version: "10.11.8"
+version: "10.11.9"
 video: true


### PR DESCRIPTION
## Summary
- Fix JELLYFIN_WEB_DIR being incorrectly redirected from `/usr/share/jellyfin/web` to `$LOCATION/web`
- Fix LOCATION fallback being a no-op (`LOCATION=$LOCATION` instead of `LOCATION=/config`) due to sed substitution order

## Root Cause
The Dockerfile sed patches had two issues:
1. `s|/usr/share/jellyfin|$LOCATION|g` replaced the web UI path, making Jellyfin unable to find its web files
2. The `/config` → `$LOCATION` substitution ran after the fallback line was inserted, replacing the `/config` fallback with `$LOCATION`

## Fix
- Removed the `/usr/share/jellyfin` sed entirely (web dir must stay at original path)
- Reordered seds: substitution first, then fallback insert