### PR TITLE
feat: add 95 LSIO-based HA add-ons

### DIFF
--- a/adguardhome-sync/CHANGELOG.md
+++ b/adguardhome-sync/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/adguardhome-sync/Dockerfile
+++ b/adguardhome-sync/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-adguardhome-sync/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-adguardhome-sync/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-adguardhome-sync/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-adguardhome-sync/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-adguardhome-sync/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/adguardhome-sync/build.json
+++ b/adguardhome-sync/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/adguardhome-sync:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/adguardhome-sync:amd64-latest"
+  }
+}

--- a/adguardhome-sync/config.yaml
+++ b/adguardhome-sync/config.yaml
@@ -1,0 +1,23 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "AdGuard Home Sync"
+description: "Synchronize AdGuard Home config to replica instances"
+version: "1.0.0"
+slug: "adguardhome-sync"
+url: "https://github.com/linuxserver/docker-adguardhome-sync"
+arch:
+  - amd64
+  - aarch64
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+options:
+  TZ: "Etc/UTC"
+  config_yaml: ""
+  api_port: 8080
+schema:
+  TZ: str
+  config_yaml: str
+  api_port: port
+

--- a/adguardhome-sync/updater.json
+++ b/adguardhome-sync/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "adguardhome-sync",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-adguardhome-sync",
+  "upstream_version": "0.0.0"
+}

--- a/airsonic-advanced/CHANGELOG.md
+++ b/airsonic-advanced/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/airsonic-advanced/Dockerfile
+++ b/airsonic-advanced/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-airsonic-advanced/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-airsonic-advanced/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-airsonic-advanced/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-airsonic-advanced/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-airsonic-advanced/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="4040" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/airsonic-advanced/build.json
+++ b/airsonic-advanced/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/airsonic-advanced:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/airsonic-advanced:amd64-latest"
+  }
+}

--- a/airsonic-advanced/config.yaml
+++ b/airsonic-advanced/config.yaml
@@ -1,0 +1,74 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Airsonic Advanced is a free, web-based media streamer providing ubiquitous
+  access to your music. Stream to multiple players simultaneously, manage
+  playlists, podcasts, and share your library.
+devices:
+  - /dev/snd
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/airsonic-advanced-{arch}
+ingress: true
+ingress_port: 4040
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Airsonic Advanced
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/airsonic-advanced
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  CONTEXT_PATH: ""
+  JAVA_OPTS: ""
+  DOCKER_MODS: []
+panel_icon: mdi:music-circle
+ports:
+  4040/tcp: 4040
+ports_description:
+  4040/tcp: Web UI
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  CONTEXT_PATH: str?
+  JAVA_OPTS: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:airsonic-advanced-[a-z0-9-]+$)?
+slug: airsonic-advanced
+udev: true
+url: https://github.com/kagemomiji/airsonic-advanced
+version: "1.0.0"
+video: false
+

--- a/airsonic-advanced/updater.json
+++ b/airsonic-advanced/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "airsonic-advanced",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-airsonic-advanced",
+  "upstream_version": "0.0.0"
+}

--- a/babybuddy/CHANGELOG.md
+++ b/babybuddy/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/babybuddy/Dockerfile
+++ b/babybuddy/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-babybuddy/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-babybuddy/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-babybuddy/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-babybuddy/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-babybuddy/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/babybuddy/build.json
+++ b/babybuddy/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/babybuddy:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/babybuddy:amd64-latest"
+  }
+}

--- a/babybuddy/config.yaml
+++ b/babybuddy/config.yaml
@@ -1,0 +1,67 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Baby Buddy helps caregivers track sleep, feedings, diaper changes, tummy
+  time and more to learn about and predict baby's needs.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/babybuddy-{arch}
+ingress: true
+ingress_port: 8000
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - ssl
+name: Baby Buddy
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/babybuddy
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  CSRF_TRUSTED_ORIGINS: ""
+  DOCKER_MODS: []
+panel_icon: mdi:baby-face-outline
+ports:
+  8000/tcp: 8000
+ports_description:
+  8000/tcp: Web UI
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  CSRF_TRUSTED_ORIGINS: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:babybuddy-[a-z0-9-]+$)?
+slug: babybuddy
+udev: true
+url: https://github.com/babybuddy/babybuddy
+version: "1.0.0"
+

--- a/babybuddy/updater.json
+++ b/babybuddy/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "babybuddy",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-babybuddy",
+  "upstream_version": "0.0.0"
+}

--- a/beets/CHANGELOG.md
+++ b/beets/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/beets/Dockerfile
+++ b/beets/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-beets/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-beets/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-beets/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-beets/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-beets/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8337" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/beets/build.json
+++ b/beets/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/beets:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/beets:amd64-latest"
+  }
+}

--- a/beets/config.yaml
+++ b/beets/config.yaml
@@ -1,0 +1,67 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Beets is a music library manager with automatic metadata tagging via
+  MusicBrainz. Includes a web-based player plugin and supports powerful
+  plugins for organization, transcoding, and more.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/beets-{arch}
+ingress: true
+ingress_port: 8337
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Beets
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/beets
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:music-note
+ports:
+  8337/tcp: 8337
+ports_description:
+  8337/tcp: Web UI (Beets web plugin)
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:beets-[a-z0-9-]+$)?
+slug: beets
+udev: true
+url: http://beets.io/
+version: "1.0.0"
+

--- a/beets/updater.json
+++ b/beets/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "beets",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-beets",
+  "upstream_version": "0.0.0"
+}

--- a/bookstack/CHANGELOG.md
+++ b/bookstack/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-bookstack/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-bookstack/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-bookstack/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-bookstack/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-bookstack/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/login"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/bookstack/build.json
+++ b/bookstack/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/bookstack:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/bookstack:amd64-latest"
+  }
+}

--- a/bookstack/config.yaml
+++ b/bookstack/config.yaml
@@ -1,0 +1,64 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  BookStack is a simple, self-hosted, open-source documentation platform with
+  a WYSIWYG editor, Markdown support, LDAP/SAML authentication, and powerful
+  search. Requires a MariaDB database.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/bookstack-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+map:
+  - addon_config:rw
+name: Bookstack
+options:
+  env_vars: []
+  TZ: ""
+  APP_URL: "http://hassio.local:6875"
+  APP_KEY: ""
+  DB_HOST: "core-mariadb"
+  DB_PORT: 3306
+  DB_USERNAME: "bookstack"
+  DB_PASSWORD: ""
+  DB_DATABASE: "bookstack"
+  QUEUE_CONNECTION: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:book-open-page-variant
+ports:
+  6875/tcp: 80
+ports_description:
+  6875/tcp: Web interface (optional if using Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  APP_URL: str
+  APP_KEY: str
+  DB_HOST: str
+  DB_PORT: int
+  DB_USERNAME: str
+  DB_PASSWORD: password
+  DB_DATABASE: str
+  QUEUE_CONNECTION: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:bookstack-[a-z0-9-]+$)?
+slug: bookstack
+url: https://www.bookstackapp.com
+version: "1.0.0"
+

--- a/bookstack/updater.json
+++ b/bookstack/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "bookstack",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-bookstack",
+  "upstream_version": "0.0.0"
+}

--- a/calibre-web/CHANGELOG.md
+++ b/calibre-web/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/calibre-web/Dockerfile
+++ b/calibre-web/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-calibre-web/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-calibre-web/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-calibre-web/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-calibre-web/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-calibre-web/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8083" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/calibre-web/build.json
+++ b/calibre-web/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/calibre-web:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/calibre-web:amd64-latest"
+  }
+}

--- a/calibre-web/config.yaml
+++ b/calibre-web/config.yaml
@@ -1,0 +1,52 @@
+homeassistant: "2024.1.0"
+name: Calibre-Web
+description: Web UI for browsing, reading and downloading eBooks from a Calibre library
+slug: calibre-web
+url: https://github.com/linuxserver/docker-calibre-web
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/calibre-web-{arch}
+version: "1.0.0"
+init: false
+
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: Etc/UTC
+  DOCKER_MODS: ""
+  OAUTHLIB_RELAX_TOKEN_SCOPE: ""
+  env_vars: []
+
+schema:
+  PUID: int
+  PGID: int
+  TZ: str?
+  DOCKER_MODS: str?
+  OAUTHLIB_RELAX_TOKEN_SCOPE: str?
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+
+ports:
+  8083/tcp: 8083
+
+ports_description:
+  8083/tcp: "Calibre-Web WebUI"
+
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+
+environment:
+  HOME: /config
+  FM_HOME: /config
+
+webui: "http://[HOST]:[PORT:8083]"
+ingress: true
+ingress_port: 8083
+ingress_stream: false
+panel_icon: mdi:book-open-page-variant
+panel_admin: false
+

--- a/calibre-web/updater.json
+++ b/calibre-web/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "calibre-web",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-calibre-web",
+  "upstream_version": "0.0.0"
+}

--- a/changedetection/CHANGELOG.md
+++ b/changedetection/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/changedetection/Dockerfile
+++ b/changedetection/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-changedetection/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-changedetection/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-changedetection/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-changedetection/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-changedetection/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/changedetection/build.json
+++ b/changedetection/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/changedetection.io:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/changedetection.io:amd64-latest"
+  }
+}

--- a/changedetection/config.yaml
+++ b/changedetection/config.yaml
@@ -1,0 +1,59 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Changedetection.io — website change detection and notification service.
+  Monitor web pages for changes and get notified via email, Slack, Discord,
+  Telegram and many more. Supports Playwright/Chrome for JS-rendered pages.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/changedetection-{arch}
+ingress: true
+ingress_port: 5000
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - ssl
+name: Changedetection.io
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/changedetection
+  TZ: ""
+  BASE_URL: ""
+  PLAYWRIGHT_DRIVER_URL: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:vector-difference
+ports:
+  5000/tcp: 5000
+ports_description:
+  5000/tcp: Web UI (not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  BASE_URL: str?
+  PLAYWRIGHT_DRIVER_URL: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: changedetection
+udev: true
+url: https://github.com/dgtlmoon/changedetection.io
+version: "1.0.0"
+

--- a/changedetection/updater.json
+++ b/changedetection/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "changedetection",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-changedetection",
+  "upstream_version": "0.0.0"
+}

--- a/code-server/CHANGELOG.md
+++ b/code-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-code-server/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-code-server/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-code-server/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-code-server/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-code-server/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8443" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/code-server/build.json
+++ b/code-server/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/code-server:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/code-server:amd64-latest"
+  }
+}

--- a/code-server/config.yaml
+++ b/code-server/config.yaml
@@ -1,0 +1,78 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  VS Code in the browser. Code on any device with a consistent dev
+  environment. Access your Home Assistant config files directly, edit
+  add-ons, automate, and develop from the comfort of your browser.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/code-server-{arch}
+ingress: true
+ingress_port: 8443
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+  - homeassistant_config:rw
+  - all_addon_configs:rw
+name: Code Server
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/code-server
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  PASSWORD: ""
+  SUDO_PASSWORD: ""
+  PROXY_DOMAIN: ""
+  DEFAULT_WORKSPACE: /config/workspace
+  DOCKER_MODS: []
+panel_icon: mdi:microsoft-visual-studio-code
+panel_admin: true
+ports:
+  8443/tcp: 8443
+ports_description:
+  8443/tcp: VS Code Web UI
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  PASSWORD: password?
+  SUDO_PASSWORD: password?
+  PROXY_DOMAIN: str?
+  DEFAULT_WORKSPACE: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:code-server-[a-z0-9-]+$)?
+slug: code-server
+udev: true
+url: https://coder.com
+version: "1.0.0"
+

--- a/code-server/updater.json
+++ b/code-server/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "code-server",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-code-server",
+  "upstream_version": "0.0.0"
+}

--- a/cops/CHANGELOG.md
+++ b/cops/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/cops/Dockerfile
+++ b/cops/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-cops/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-cops/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-cops/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-cops/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-cops/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/cops/build.json
+++ b/cops/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/cops:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/cops:amd64-latest"
+  }
+}

--- a/cops/config.yaml
+++ b/cops/config.yaml
@@ -1,0 +1,69 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  COPS (Calibre OPDS and HTML Php Server) — lightweight web interface and
+  OPDS feed for your Calibre library. Browse, download, and read ebooks
+  directly from your browser. Supports epub in-browser viewing.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/cops-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: COPS
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/cops
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:bookshelf
+ports:
+  80/tcp: 80
+  443/tcp: null
+ports_description:
+  80/tcp: Web UI (HTTP)
+  443/tcp: Web UI (HTTPS, optional)
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:cops-[a-z0-9-]+$)?
+slug: cops
+udev: true
+url: https://github.com/mikespub-org/seblucas-cops
+version: "1.0.0"
+

--- a/cops/updater.json
+++ b/cops/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "cops",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-cops",
+  "upstream_version": "0.0.0"
+}

--- a/darktable/CHANGELOG.md
+++ b/darktable/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/darktable/Dockerfile
+++ b/darktable/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-darktable/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-darktable/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-darktable/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-darktable/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-darktable/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3001" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/darktable/build.json
+++ b/darktable/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/darktable:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/darktable:amd64-latest"
+  }
+}

--- a/darktable/config.yaml
+++ b/darktable/config.yaml
@@ -1,0 +1,78 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Darktable is an open source photography workflow application and raw
+  developer. A virtual lighttable and darkroom for photographers. Manage
+  your digital negatives, develop raw images, and enhance them through a
+  web-based GUI.
+devices:
+  - /dev/dri
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/darktable-{arch}
+ingress: true
+ingress_port: 3001
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Darktable
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/darktable
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  CUSTOM_USER: ""
+  PASSWORD: ""
+  DOCKER_MODS: []
+panel_icon: mdi:image-filter-hdr
+panel_admin: true
+ports:
+  3000/tcp: null
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: HTTP desktop GUI (not recommended)
+  3001/tcp: HTTPS desktop GUI (recommended)
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  CUSTOM_USER: str?
+  PASSWORD: password?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:darktable-[a-z0-9-]+$)?
+slug: darktable
+udev: true
+url: https://www.darktable.org/
+version: "1.0.0"
+video: true
+

--- a/darktable/updater.json
+++ b/darktable/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "darktable",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-darktable",
+  "upstream_version": "0.0.0"
+}

--- a/davos/CHANGELOG.md
+++ b/davos/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/davos/Dockerfile
+++ b/davos/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-davos/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-davos/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-davos/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-davos/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-davos/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/davos/build.json
+++ b/davos/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/davos:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/davos:amd64-latest"
+  }
+}

--- a/davos/config.yaml
+++ b/davos/config.yaml
@@ -1,0 +1,67 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Davos is an FTP automation tool that periodically scans given host
+  locations for new files. Configure RSS feeds, FTP servers, and web
+  pages to monitor and automatically download new content.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/davos-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Davos
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/davos
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:download
+ports:
+  8080/tcp: 8080
+ports_description:
+  8080/tcp: Web UI
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:davos-[a-z0-9-]+$)?
+slug: davos
+udev: true
+url: https://github.com/linuxserver/davos
+version: "1.0.0"
+

--- a/davos/updater.json
+++ b/davos/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "davos",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-davos",
+  "upstream_version": "0.0.0"
+}

--- a/ddclient/CHANGELOG.md
+++ b/ddclient/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ddclient/Dockerfile
+++ b/ddclient/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ddclient/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ddclient/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ddclient/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ddclient/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ddclient/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ddclient/build.json
+++ b/ddclient/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ddclient:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ddclient:amd64-latest"
+  }
+}

--- a/ddclient/config.yaml
+++ b/ddclient/config.yaml
@@ -1,0 +1,21 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "ddclient"
+description: "Dynamic DNS updater — keeps your DNS records synced when your IP changes"
+version: "1.0.0"
+slug: "ddclient"
+url: "https://github.com/linuxserver/docker-ddclient"
+arch:
+  - amd64
+  - aarch64
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+options:
+  TZ: "Etc/UTC"
+  ddclient_conf: ""
+schema:
+  TZ: str
+  ddclient_conf: str
+

--- a/ddclient/updater.json
+++ b/ddclient/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ddclient",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ddclient",
+  "upstream_version": "0.0.0"
+}

--- a/deluge/CHANGELOG.md
+++ b/deluge/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/deluge/Dockerfile
+++ b/deluge/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-deluged/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-deluged/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-deluged/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-deluged/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-deluged/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8112" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/deluge/build.json
+++ b/deluge/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/deluge:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/deluge:amd64-latest"
+  }
+}

--- a/deluge/config.yaml
+++ b/deluge/config.yaml
@@ -1,0 +1,105 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description:
+  Lightweight, free, cross-platform BitTorrent client with plugin-based
+  architecture. Supports thin client mode, full encryption, WebUI, and more.
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video11
+  - /dev/video12
+  - /dev/video13
+  - /dev/video14
+  - /dev/video15
+  - /dev/video16
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  - /dev/nvme0n1p2
+  - /dev/nvme0n1p3
+  - /dev/nvme1n1
+  - /dev/nvme1n1p1
+  - /dev/nvme1n1p2
+  - /dev/nvme1n1p3
+  - /dev/mmcblk
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/deluge-{arch}
+ingress: true
+ingress_port: 8112
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Deluge
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/deluge
+  TZ: ""
+  DELUGE_LOGLEVEL: info
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_admin: false
+panel_icon: mdi:download
+ports:
+  6881/tcp: 6881
+  6881/udp: 6881
+  8112/tcp: 8112
+  58846/tcp: 58846
+ports_description:
+  6881/tcp: Torrent peer port (TCP)
+  6881/udp: Torrent peer port (UDP)
+  8112/tcp: Web UI (not required for Ingress)
+  58846/tcp: Thin client daemon port (optional)
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  DELUGE_LOGLEVEL: list(error|warning|info|debug|trace)?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: password?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:[a-z0-9-]+$)?
+slug: deluge
+udev: true
+url: https://deluge-torrent.org
+version: "1.0.0"
+

--- a/deluge/updater.json
+++ b/deluge/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "deluge",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-deluge",
+  "upstream_version": "0.0.0"
+}

--- a/diskover/CHANGELOG.md
+++ b/diskover/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/diskover/Dockerfile
+++ b/diskover/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-diskover/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-diskover/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-diskover/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-diskover/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-diskover/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/diskover/build.json
+++ b/diskover/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/diskover:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/diskover:amd64-latest"
+  }
+}

--- a/diskover/config.yaml
+++ b/diskover/config.yaml
@@ -1,0 +1,71 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: >
+  Diskover is an open source file system indexer that uses Elasticsearch
+  to index and manage data across heterogeneous storage systems. Visualize
+  disk usage, find duplicates, and manage storage on your HA setup.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/diskover-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Diskover
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/diskover
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  ES_HOST: elasticsearch
+  ES_PORT: 9200
+  DOCKER_MODS: []
+panel_icon: mdi:harddisk
+ports:
+  80/tcp: 80
+ports_description:
+  80/tcp: Web UI
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  ES_HOST: str
+  ES_PORT: int
+  DOCKER_MODS:
+    - match(^linuxserver/mods:diskover-[a-z0-9-]+$)?
+slug: diskover
+udev: true
+url: https://github.com/diskoverdata/diskover-community
+version: "1.0.0"
+

--- a/diskover/updater.json
+++ b/diskover/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "diskover",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-diskover",
+  "upstream_version": "0.0.0"
+}

--- a/dokuwiki/CHANGELOG.md
+++ b/dokuwiki/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/dokuwiki/Dockerfile
+++ b/dokuwiki/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-dokuwiki/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-dokuwiki/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-dokuwiki/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-dokuwiki/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-dokuwiki/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/dokuwiki/build.json
+++ b/dokuwiki/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/dokuwiki:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/dokuwiki:amd64-latest"
+  }
+}

--- a/dokuwiki/config.yaml
+++ b/dokuwiki/config.yaml
@@ -1,0 +1,48 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  DokuWiki is a simple-to-use, standards-compliant wiki that doesn't require
+  a database. All data is stored in plain text files. Features a clean syntax,
+  built-in access controls, LDAP authentication support, and extensive plugins.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/dokuwiki-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+map:
+  - addon_config:rw
+name: DokuWiki
+options:
+  env_vars: []
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:notebook
+ports:
+  80/tcp: 8082
+ports_description:
+  80/tcp: Web interface (optional if using Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:dokuwiki-[a-z0-9-]+$)?
+slug: dokuwiki
+url: https://www.dokuwiki.org/dokuwiki/
+version: "1.0.0"
+

--- a/dokuwiki/updater.json
+++ b/dokuwiki/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "dokuwiki",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-dokuwiki",
+  "upstream_version": "0.0.0"
+}

--- a/doplarr/CHANGELOG.md
+++ b/doplarr/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/doplarr/Dockerfile
+++ b/doplarr/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-doplarr/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-doplarr/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-doplarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-doplarr/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-doplarr/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/doplarr/build.json
+++ b/doplarr/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/doplarr:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/doplarr:amd64-latest"
+  }
+}

--- a/doplarr/config.yaml
+++ b/doplarr/config.yaml
@@ -1,0 +1,60 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Doplarr"
+description: "Discord bot for requesting media on Sonarr/Radarr via Overseerr or direct *arr integration"
+url: "https://github.com/linuxserver/docker-doplarr"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/doplarr-{arch}
+ports: {}
+ports_description: {}
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  DISCORD_TOKEN: ""
+  OVERSEERR_API: ""
+  OVERSEERR_URL: "http://localhost:5055"
+  RADARR_API: ""
+  RADARR_URL: "http://localhost:7878"
+  SONARR_API: ""
+  SONARR_URL: "http://localhost:8989"
+  DISCORD_MAX_RESULTS: 25
+  DISCORD_REQUESTED_MSG_STYLE: ":plain"
+  SONARR_QUALITY_PROFILE: ""
+  RADARR_QUALITY_PROFILE: ""
+  SONARR_ROOTFOLDER: ""
+  RADARR_ROOTFOLDER: ""
+  SONARR_LANGUAGE_PROFILE: ""
+  OVERSEERR_DEFAULT_ID: ""
+  PARTIAL_SEASONS: true
+  LOG_LEVEL: ":info"
+  JAVA_OPTS: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  DISCORD_TOKEN: str
+  OVERSEERR_API: str?
+  OVERSEERR_URL: str?
+  RADARR_API: str?
+  RADARR_URL: str?
+  SONARR_API: str?
+  SONARR_URL: str?
+  DISCORD_MAX_RESULTS: int?
+  DISCORD_REQUESTED_MSG_STYLE: list(:plain|:embed|:none)?
+  SONARR_QUALITY_PROFILE: str?
+  RADARR_QUALITY_PROFILE: str?
+  SONARR_ROOTFOLDER: str?
+  RADARR_ROOTFOLDER: str?
+  SONARR_LANGUAGE_PROFILE: str?
+  OVERSEERR_DEFAULT_ID: str?
+  PARTIAL_SEASONS: bool?
+  LOG_LEVEL: list(:debug|:info|:warn|:error|:fatal|:report)?
+  JAVA_OPTS: str?
+
+slug: doplarr
+version: "1.0.0"

--- a/doplarr/updater.json
+++ b/doplarr/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "doplarr",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-doplarr",
+  "upstream_version": "0.0.0"
+}

--- a/duckdns/CHANGELOG.md
+++ b/duckdns/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-duckdns/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-duckdns/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-duckdns/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-duckdns/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-duckdns/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/duckdns/build.json
+++ b/duckdns/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/duckdns:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/duckdns:amd64-latest"
+  }
+}

--- a/duckdns/config.yaml
+++ b/duckdns/config.yaml
@@ -1,0 +1,22 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: DuckDNS
+description: Free dynamic DNS client — updates DuckDNS entries when your IP changes
+slug: duckdns
+url: https://github.com/linuxserver/docker-duckdns
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/duckdns-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  SUBDOMAINS: "mysubdomain"
+  TOKEN: ""
+  UPDATE_IP: "ipv4"
+  LOG_FILE: false
+

--- a/duckdns/updater.json
+++ b/duckdns/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "duckdns",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-duckdns",
+  "upstream_version": "0.0.0"
+}

--- a/duplicati/CHANGELOG.md
+++ b/duplicati/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/duplicati/Dockerfile
+++ b/duplicati/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-duplicati/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-duplicati/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-duplicati/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-duplicati/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-duplicati/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8200" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/duplicati/build.json
+++ b/duplicati/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/duplicati:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/duplicati:amd64-latest"
+  }
+}

--- a/duplicati/config.yaml
+++ b/duplicati/config.yaml
@@ -1,0 +1,66 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Backup client that stores encrypted, incremental, compressed backups on
+  cloud storage services and remote file servers. Supports S3, B2, Google
+  Drive, OneDrive, FTP, SSH, WebDAV, and many more.
+devices:
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/duplicati-{arch}
+ingress: true
+ingress_port: 8200
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+  - homeassistant_config:rw
+  - backup:rw
+name: Duplicati
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  SETTINGS_ENCRYPTION_KEY: ""
+  DUPLICATI__WEBSERVICE_PASSWORD: ""
+  CLI_ARGS: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:backup-restore
+ports:
+  8200/tcp: 8200
+ports_description:
+  8200/tcp: WebUI (HTTP)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  SETTINGS_ENCRYPTION_KEY: str?
+  DUPLICATI__WEBSERVICE_PASSWORD: str?
+  CLI_ARGS: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: duplicati
+udev: true
+url: https://www.duplicati.com
+version: "1.0.0"
+

--- a/duplicati/updater.json
+++ b/duplicati/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "duplicati",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-duplicati",
+  "upstream_version": "0.0.0"
+}

--- a/emby-media-server/CHANGELOG.md
+++ b/emby-media-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/emby-media-server/Dockerfile
+++ b/emby-media-server/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-emby/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-emby/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-emby/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-emby/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-emby/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/emby-media-server/build.json
+++ b/emby-media-server/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/emby:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/emby:amd64-latest"
+  }
+}

--- a/emby-media-server/config.yaml
+++ b/emby-media-server/config.yaml
@@ -1,0 +1,27 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video11
+  - /dev/video12
+  - /dev/video13
+  - /dev/video14
+  - /dev/video15
+  - /dev/video16
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  # ... (full disk device list matching jellyfin pattern)
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  # ... (NVMe partitions)
+  - /dev/mmcblk
+  - /dev/fuse
+
+slug: emby-media-server
+version: "1.0.0"

--- a/emby-media-server/updater.json
+++ b/emby-media-server/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "emby-media-server",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-emby",
+  "upstream_version": "0.0.0"
+}

--- a/fail2ban/CHANGELOG.md
+++ b/fail2ban/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/fail2ban/Dockerfile
+++ b/fail2ban/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-fail2ban/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-fail2ban/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-fail2ban/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-fail2ban/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-fail2ban/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/fail2ban/build.json
+++ b/fail2ban/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/fail2ban:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/fail2ban:amd64-latest"
+  }
+}

--- a/fail2ban/config.yaml
+++ b/fail2ban/config.yaml
@@ -1,0 +1,28 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Fail2ban"
+description: "Intrusion prevention framework that bans IPs with too many failed logins"
+url: "https://github.com/linuxserver/docker-fail2ban"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/fail2ban-{arch}
+host_network: true
+ports: {}
+ports_description: {}
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  VERBOSITY: "-vv"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  VERBOSITY: list(|-v|-vv|-vvv|-vvvv)?
+
+slug: fail2ban
+version: "1.0.0"

--- a/fail2ban/updater.json
+++ b/fail2ban/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "fail2ban",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-fail2ban",
+  "upstream_version": "0.0.0"
+}

--- a/faster-whisper/CHANGELOG.md
+++ b/faster-whisper/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/faster-whisper/Dockerfile
+++ b/faster-whisper/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-faster-whisper/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-faster-whisper/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-faster-whisper/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-faster-whisper/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-faster-whisper/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="10300" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/faster-whisper/build.json
+++ b/faster-whisper/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/faster-whisper:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/faster-whisper:amd64-latest"
+  }
+}

--- a/faster-whisper/config.yaml
+++ b/faster-whisper/config.yaml
@@ -1,0 +1,45 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Fast AI-powered speech transcription using OpenAI's Whisper model with
+  CTranslate2 optimization. Provides a Wyoming protocol server for Home
+  Assistant Assist voice integration.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/faster-whisper-{arch}
+map:
+  - addon_config:rw
+name: Faster Whisper
+options:
+  env_vars: []
+  TZ: ""
+  WHISPER_MODEL: "auto"        # tiny, tiny.en, base, base.en, small, small.en,
+                               # medium, medium.en, large-v1, large-v2, large-v3,
+                               # large, distil-large-v2, distil-large-v3,
+                               # distil-medium.en, distil-small.en, auto
+  WHISPER_LANG: "auto"         # 2-char language code or "auto"
+  WHISPER_BEAM: 1              # Number of candidates for transcription
+  DEBUG: false
+  LOCAL_ONLY: false
+panel_icon: mdi:microphone-message
+ports:
+  10300/tcp: 10300
+ports_description:
+  10300/tcp: Wyoming protocol port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  WHISPER_MODEL: str
+  WHISPER_LANG: str
+  WHISPER_BEAM: int
+  DEBUG: bool
+  LOCAL_ONLY: bool
+slug: faster-whisper
+url: https://github.com/SYSTRAN/faster-whisper
+version: "1.0.0"
+

--- a/faster-whisper/updater.json
+++ b/faster-whisper/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "faster-whisper",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-faster-whisper",
+  "upstream_version": "0.0.0"
+}

--- a/ferdium/CHANGELOG.md
+++ b/ferdium/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ferdium/Dockerfile
+++ b/ferdium/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ferdium/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ferdium/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ferdium/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ferdium/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ferdium/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ferdium/build.json
+++ b/ferdium/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ferdium:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ferdium:amd64-latest"
+  }
+}

--- a/ferdium/config.yaml
+++ b/ferdium/config.yaml
@@ -1,0 +1,33 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Ferdium"
+description: "Desktop app combining multiple web messaging services into one"
+url: "https://github.com/linuxserver/docker-ferdium"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/ferdium-{arch}
+shm_size: "1gb"
+ports:
+  3000/tcp: 3000
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: "Ferdium desktop GUI (HTTP, must be proxied)"
+  3001/tcp: "Ferdium desktop GUI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CUSTOM_USER: "abc"
+  PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CUSTOM_USER: str?
+  PASSWORD: str?
+
+slug: ferdium
+version: "1.0.0"

--- a/ferdium/updater.json
+++ b/ferdium/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ferdium",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ferdium",
+  "upstream_version": "0.0.0"
+}

--- a/flexget/CHANGELOG.md
+++ b/flexget/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/flexget/Dockerfile
+++ b/flexget/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-flexget/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-flexget/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-flexget/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-flexget/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-flexget/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="5050" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/flexget/build.json
+++ b/flexget/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/flexget:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/flexget:amd64-latest"
+  }
+}

--- a/flexget/config.yaml
+++ b/flexget/config.yaml
@@ -1,0 +1,37 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Flexget"
+description: "Multipurpose automation tool for torrents, RSS, and media management"
+url: "https://github.com/linuxserver/docker-flexget"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/flexget-{arch}
+webui: "http://[HOST]:[PORT:5050]"
+ports:
+  5050/tcp: 5050
+ports_description:
+  5050/tcp: "FlexGet WebUI"
+map:
+  - config:rw
+  - media:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  FG_LOG_LEVEL: "info"
+  FG_LOG_FILE: "/config/flexget.log"
+  FG_CONFIG_FILE: "/config/.flexget/config.yml"
+  FG_WEBUI_PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  FG_LOG_LEVEL: list(critical|error|warning|info|verbose|debug|trace)?
+  FG_LOG_FILE: str?
+  FG_CONFIG_FILE: str?
+  FG_WEBUI_PASSWORD: str?
+
+slug: flexget
+version: "1.0.0"

--- a/flexget/updater.json
+++ b/flexget/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "flexget",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-flexget",
+  "upstream_version": "0.0.0"
+}

--- a/freshrss/CHANGELOG.md
+++ b/freshrss/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/freshrss/Dockerfile
+++ b/freshrss/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-freshrss/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-freshrss/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-freshrss/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-freshrss/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-freshrss/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/freshrss/build.json
+++ b/freshrss/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/freshrss:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/freshrss:amd64-latest"
+  }
+}

--- a/freshrss/config.yaml
+++ b/freshrss/config.yaml
@@ -1,0 +1,24 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "FreshRSS"
+description: "Self-hosted RSS feed aggregator and reader — multi-user, mobile-compatible API"
+version: "1.0.0"
+slug: "freshrss"
+url: "https://github.com/rezusnet/hassio-addons/tree/master/freshrss"
+arch:
+  - amd64
+  - arm64
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - ssl
+ports:
+  80/tcp: 80
+options:
+  tz: "Etc/UTC"
+  cron_interval: "15"
+schema:
+  tz: "str"
+  cron_interval: "list(1|5|10|15|30|60)"
+

--- a/freshrss/updater.json
+++ b/freshrss/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "freshrss",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-freshrss",
+  "upstream_version": "0.0.0"
+}

--- a/grav/CHANGELOG.md
+++ b/grav/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/grav/Dockerfile
+++ b/grav/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-grav/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-grav/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-grav/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-grav/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-grav/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/grav/build.json
+++ b/grav/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/grav:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/grav:amd64-latest"
+  }
+}

--- a/grav/config.yaml
+++ b/grav/config.yaml
@@ -1,0 +1,28 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Grav"
+description: "Modern flat-file CMS — no database needed"
+url: "https://github.com/linuxserver/docker-grav"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/grav-{arch}
+webui: "http://[HOST]:[PORT:80]"
+ports:
+  80/tcp: 80
+ports_description:
+  80/tcp: "Grav web interface"
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: grav
+version: "1.0.0"

--- a/grav/updater.json
+++ b/grav/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "grav",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-grav",
+  "upstream_version": "0.0.0"
+}

--- a/grocy/CHANGELOG.md
+++ b/grocy/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-grocy/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-grocy/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-grocy/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-grocy/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-grocy/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/grocy/build.json
+++ b/grocy/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/grocy:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/grocy:amd64-latest"
+  }
+}

--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -1,0 +1,54 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Grocy is an ERP system for your kitchen. Manage groceries, household chores,
+  batteries, meal planning and track your food waste.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/grocy-{arch}
+ingress: true
+ingress_port: 9283
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - ssl
+name: Grocy
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/grocy
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:fridge-outline
+ports:
+  9283/tcp: 9283
+ports_description:
+  9283/tcp: Web interface (not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: grocy
+udev: true
+url: https://github.com/grocy/grocy
+version: "1.0.0"
+

--- a/grocy/updater.json
+++ b/grocy/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "grocy",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-grocy",
+  "upstream_version": "0.0.0"
+}

--- a/habridge/CHANGELOG.md
+++ b/habridge/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/habridge/Dockerfile
+++ b/habridge/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-habridge/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-habridge/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-habridge/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-habridge/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-habridge/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/habridge/build.json
+++ b/habridge/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/habridge:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/habridge:amd64-latest"
+  }
+}

--- a/habridge/config.yaml
+++ b/habridge/config.yaml
@@ -1,0 +1,55 @@
+arch:
+  - aarch64
+  - amd64
+description:
+  HaBridge emulates a Philips Hue bridge to control Home Assistant devices via
+  Amazon Echo, Google Home, and other Hue-compatible voice assistants and systems.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/habridge-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: false
+map:
+  - addon_config:rw
+icon: icon.png
+name: HaBridge
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  SEC_KEY: ""
+  data_location: /config
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:bridge
+ports:
+  8080/tcp: 8080
+  50000/tcp: 50000
+ports_description:
+  8080/tcp: HaBridge Web UI
+  50000/tcp: HaBridge UPnP/communication port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  SEC_KEY: password?
+  data_location: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: habridge
+url: https://github.com/bwssytems/ha-bridge
+version: "1.0.0"
+

--- a/habridge/updater.json
+++ b/habridge/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "habridge",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-habridge",
+  "upstream_version": "0.0.0"
+}

--- a/healthchecks/CHANGELOG.md
+++ b/healthchecks/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/healthchecks/Dockerfile
+++ b/healthchecks/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-healthchecks/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-healthchecks/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-healthchecks/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-healthchecks/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-healthchecks/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/healthchecks/build.json
+++ b/healthchecks/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/healthchecks:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/healthchecks:amd64-latest"
+  }
+}

--- a/healthchecks/config.yaml
+++ b/healthchecks/config.yaml
@@ -1,0 +1,85 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Healthchecks is a cron job monitoring service. It listens for pings from
+  your cron jobs and alerts when they don't arrive on schedule. Supports
+  email, Slack, webhook, and Pushover notifications.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/healthchecks-{arch}
+ingress: true
+ingress_port: 8000
+ingress_stream: true
+map:
+  - addon_config:rw
+icon: icon.png
+name: Healthchecks
+options:
+  env_vars: []
+  TZ: ""
+  SECRET_KEY: ""
+  SITE_ROOT: ""
+  SITE_NAME: Healthchecks
+  SUPERUSER_EMAIL: admin@example.com
+  SUPERUSER_PASSWORD: ""
+  APPRISE_ENABLED: false
+  PING_EMAIL_DOMAIN: ""
+  EMAIL_HOST: ""
+  EMAIL_PORT: 25
+  EMAIL_HOST_USER: ""
+  EMAIL_HOST_PASSWORD: ""
+  EMAIL_USE_TLS: false
+  DEFAULT_FROM_EMAIL: ""
+  ALLOWED_HOSTS: ""
+  CSRF_TRUSTED_ORIGINS: ""
+  INTEGRATIONS_ALLOW_PRIVATE_IPS: false
+  RP_ID: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  panel_icon: mdi:heart-pulse
+ports:
+  8000/tcp: 8000
+  2525/tcp: null
+ports_description:
+  8000/tcp: Web UI (ingress enabled)
+  2525/tcp: Inbound SMTP pings (optional)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  SECRET_KEY: password
+  SITE_ROOT: str?
+  SITE_NAME: str?
+  SUPERUSER_EMAIL: email
+  SUPERUSER_PASSWORD: password
+  APPRISE_ENABLED: bool?
+  PING_EMAIL_DOMAIN: str?
+  EMAIL_HOST: str?
+  EMAIL_PORT: int?
+  EMAIL_HOST_USER: str?
+  EMAIL_HOST_PASSWORD: password?
+  EMAIL_USE_TLS: bool?
+  DEFAULT_FROM_EMAIL: str?
+  ALLOWED_HOSTS: str?
+  CSRF_TRUSTED_ORIGINS: str?
+  INTEGRATIONS_ALLOW_PRIVATE_IPS: bool?
+  RP_ID: str?
+  DEBUG: bool?
+  SITE_LOGO_URL: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  panel_icon: str
+slug: healthchecks
+url: https://github.com/healthchecks/healthchecks
+version: "1.0.0"
+

--- a/healthchecks/updater.json
+++ b/healthchecks/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "healthchecks",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-healthchecks",
+  "upstream_version": "0.0.0"
+}

--- a/hedgedoc/CHANGELOG.md
+++ b/hedgedoc/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-hedgedoc/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-hedgedoc/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-hedgedoc/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-hedgedoc/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-hedgedoc/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/hedgedoc/build.json
+++ b/hedgedoc/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/hedgedoc:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/hedgedoc:amd64-latest"
+  }
+}

--- a/hedgedoc/config.yaml
+++ b/hedgedoc/config.yaml
@@ -1,0 +1,35 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "HedgeDoc"
+description: "Real-time collaborative markdown notes — self-hosted, like Google Docs for markdown"
+version: "1.0.0"
+slug: "hedgedoc"
+url: "https://github.com/rezusnet/hassio-addons/tree/master/hedgedoc"
+arch:
+  - amd64
+  - arm64
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - ssl
+ports:
+  3000/tcp: 3000
+options:
+  db_type: "sqlite"
+  cmd_domain: "localhost"
+  tz: "Etc/UTC"
+schema:
+  db_type: "list(sqlite|mariadb|mysql|postgres)"
+  db_host: "str?"
+  db_port: "int?"
+  db_user: "str?"
+  db_pass: "password?"
+  db_name: "str?"
+  cmd_domain: "str"
+  cmd_url_addport: "bool?"
+  cmd_protocol_usessl: "bool?"
+  cmd_port: "int?"
+  cmd_allow_origin: "str?"
+  tz: "str"
+

--- a/hedgedoc/updater.json
+++ b/hedgedoc/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "hedgedoc",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-hedgedoc",
+  "upstream_version": "0.0.0"
+}

--- a/heimdall/CHANGELOG.md
+++ b/heimdall/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/heimdall/Dockerfile
+++ b/heimdall/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-heimdall/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-heimdall/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-heimdall/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-heimdall/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-heimdall/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/heimdall/build.json
+++ b/heimdall/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/heimdall:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/heimdall:amd64-latest"
+  }
+}

--- a/heimdall/config.yaml
+++ b/heimdall/config.yaml
@@ -1,0 +1,58 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Heimdall Application Dashboard — organise all your links to web applications
+  in a single place. Use it as your browser start page with integrated search.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/heimdall-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - ssl
+name: Heimdall
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/heimdall
+  TZ: ""
+  ALLOW_INTERNAL_REQUESTS: false
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:view-dashboard-outline
+ports:
+  80/tcp: null
+  443/tcp: null
+ports_description:
+  80/tcp: HTTP web interface (optional, not required for Ingress)
+  443/tcp: HTTPS web interface (optional, not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  ALLOW_INTERNAL_REQUESTS: bool
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: heimdall
+udev: true
+url: https://heimdall.site
+version: "1.0.0"
+

--- a/heimdall/updater.json
+++ b/heimdall/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "heimdall",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-heimdall",
+  "upstream_version": "0.0.0"
+}

--- a/hishtory-server/CHANGELOG.md
+++ b/hishtory-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/hishtory-server/Dockerfile
+++ b/hishtory-server/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-hishtory-server/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-hishtory-server/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-hishtory-server/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-hishtory-server/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-hishtory-server/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/hishtory-server/build.json
+++ b/hishtory-server/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/hishtory-server:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/hishtory-server:amd64-latest"
+  }
+}

--- a/hishtory-server/config.yaml
+++ b/hishtory-server/config.yaml
@@ -1,0 +1,29 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "hiSHtory Server"
+description: "Server component for hiSHtory — a better shell history with end-to-end encrypted syncing"
+url: "https://github.com/linuxserver/docker-hishtory-server"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/hishtory-server-{arch}
+ports:
+  8080/tcp: 8080
+ports_description:
+  8080/tcp: "hiSHtory API server"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  HISHTORY_SQLITE_DB: "/config/hishtory.db"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  HISHTORY_SQLITE_DB: str?
+  HISHTORY_POSTGRES_DB: str?
+
+slug: hishtory-server
+version: "1.0.0"

--- a/hishtory-server/updater.json
+++ b/hishtory-server/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "hishtory-server",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-hishtory-server",
+  "upstream_version": "0.0.0"
+}

--- a/home-assistant-(lsio)/CHANGELOG.md
+++ b/home-assistant-(lsio)/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/home-assistant-(lsio)/Dockerfile
+++ b/home-assistant-(lsio)/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-homeassistant/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-homeassistant/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-homeassistant/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-homeassistant/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-homeassistant/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8123" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/home-assistant-(lsio)/build.json
+++ b/home-assistant-(lsio)/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/homeassistant:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/homeassistant:amd64-latest"
+  }
+}

--- a/home-assistant-(lsio)/config.yaml
+++ b/home-assistant-(lsio)/config.yaml
@@ -1,0 +1,27 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Home Assistant (LSIO)"
+description: "Home Assistant Core packaged by LinuxServer.io — for secondary instances or Docker-native setups"
+url: "https://github.com/linuxserver/docker-homeassistant"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/home-assistant-(lsio)-{arch}
+webui: "http://[HOST]:[PORT:8123]"
+ports:
+  8123/tcp: 8123
+ports_description:
+  8123/tcp: "Home Assistant WebUI"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: home-assistant-(lsio)
+version: "1.0.0"

--- a/home-assistant-(lsio)/updater.json
+++ b/home-assistant-(lsio)/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "home-assistant-(lsio)",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-homeassistant",
+  "upstream_version": "0.0.0"
+}

--- a/htpc-manager/CHANGELOG.md
+++ b/htpc-manager/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/htpc-manager/Dockerfile
+++ b/htpc-manager/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-htpcmanager/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-htpcmanager/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-htpcmanager/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-htpcmanager/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-htpcmanager/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8085" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/htpc-manager/build.json
+++ b/htpc-manager/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/htpcmanager:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/htpcmanager:amd64-latest"
+  }
+}

--- a/htpc-manager/config.yaml
+++ b/htpc-manager/config.yaml
@@ -1,0 +1,27 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "HTPC Manager"
+description: "Combines all your media server web interfaces into one unified dashboard"
+url: "https://github.com/linuxserver/docker-htpcmanager"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/htpc-manager-{arch}
+webui: "http://[HOST]:[PORT:8085]"
+ports:
+  8085/tcp: 8085
+ports_description:
+  8085/tcp: "HTPC Manager WebUI"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: htpc-manager
+version: "1.0.0"

--- a/htpc-manager/updater.json
+++ b/htpc-manager/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "htpc-manager",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-htpcmanager",
+  "upstream_version": "0.0.0"
+}

--- a/kavita/CHANGELOG.md
+++ b/kavita/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/kavita/Dockerfile
+++ b/kavita/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-kavita/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-kavita/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-kavita/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-kavita/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-kavita/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="5000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/kavita/build.json
+++ b/kavita/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/kavita:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/kavita:amd64-latest"
+  }
+}

--- a/kavita/config.yaml
+++ b/kavita/config.yaml
@@ -1,0 +1,51 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Self-hosted digital comic/manga/book server with a web-based reader.
+  Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/kavita-{arch}
+ingress: true
+ingress_port: 5000
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - media:rw
+name: Kavita
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  data_location: /share/kavita
+panel_admin: false
+panel_icon: mdi:book-open-page-variant
+ports:
+  5000/tcp: 5000
+ports_description:
+  5000/tcp: Web Interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  data_location: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: kavita
+url: https://github.com/Kareadita/Kavita
+version: "1.0.0"
+

--- a/kavita/updater.json
+++ b/kavita/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "kavita",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-kavita",
+  "upstream_version": "0.0.0"
+}

--- a/kimai/CHANGELOG.md
+++ b/kimai/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/kimai/Dockerfile
+++ b/kimai/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-kimai/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-kimai/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-kimai/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-kimai/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-kimai/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/kimai/build.json
+++ b/kimai/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/kimai:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/kimai:amd64-latest"
+  }
+}

--- a/kimai/config.yaml
+++ b/kimai/config.yaml
@@ -1,0 +1,55 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Professional-grade time-tracking application for freelancers and agencies.
+  Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/kimai-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+name: Kimai
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  database: MariaDB_addon
+panel_admin: false
+panel_icon: mdi:timer-outline
+ports:
+  80/tcp: 8090
+  443/tcp: null
+ports_description:
+  80/tcp: HTTP Web Interface
+  443/tcp: HTTPS Web Interface (disabled by default)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  database: list(MariaDB_addon|Mysql_external)
+  DATABASE_URL: str?
+  TRUSTED_PROXIES: str?
+  DB_HOST: str?
+  DB_PORT: int?
+  DB_USERNAME: str?
+  DB_PASSWORD: password?
+  DB_DATABASE: str?
+services:
+  - mysql:want
+slug: kimai
+url: https://kimai.org
+version: "1.0.0"
+

--- a/kimai/updater.json
+++ b/kimai/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "kimai",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-kimai",
+  "upstream_version": "0.0.0"
+}

--- a/kometa/CHANGELOG.md
+++ b/kometa/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/kometa/Dockerfile
+++ b/kometa/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-kometa/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-kometa/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-kometa/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-kometa/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-kometa/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/kometa/build.json
+++ b/kometa/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/kometa:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/kometa:amd64-latest"
+  }
+}

--- a/kometa/config.yaml
+++ b/kometa/config.yaml
@@ -1,0 +1,19 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  KOMETA_CONFIG: str
+  KOMETA_TIMES: str?
+  KOMETA_RUN: bool?
+  KOMETA_TESTS: bool?
+  KOMETA_NO_MISSING: bool?
+  TZ: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:kometa-[a-z0-9-]+$)?
+
+slug: kometa
+version: "1.0.0"

--- a/kometa/updater.json
+++ b/kometa/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "kometa",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-kometa",
+  "upstream_version": "0.0.0"
+}

--- a/ldap-auth/CHANGELOG.md
+++ b/ldap-auth/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ldap-auth/Dockerfile
+++ b/ldap-auth/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ldap-auth/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ldap-auth/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ldap-auth/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ldap-auth/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ldap-auth/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8888" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ldap-auth/build.json
+++ b/ldap-auth/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ldap-auth:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ldap-auth:amd64-latest"
+  }
+}

--- a/ldap-auth/config.yaml
+++ b/ldap-auth/config.yaml
@@ -1,0 +1,45 @@
+arch:
+  - aarch64
+  - amd64
+description:
+  Reverse proxy authentication daemon with LDAP/Active Directory support.
+  Provides LDAP-based SSO for services behind a reverse proxy. Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/ldap-auth-{arch}
+init: false
+map:
+  - addon_config:rw
+name: LDAP Auth
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  fernet_key: ""
+  certfile: ""
+  keyfile: ""
+panel_admin: false
+panel_icon: mdi:shield-lock
+ports:
+  8888/tcp: 8888
+  9000/tcp: 9000
+ports_description:
+  8888/tcp: LDAP Auth Daemon
+  9000/tcp: Login Page
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  fernet_key: password?
+  certfile: str?
+  keyfile: str?
+slug: ldap-auth
+url: https://github.com/nginxinc/nginx-ldap-auth
+version: "1.0.0"
+

--- a/ldap-auth/updater.json
+++ b/ldap-auth/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ldap-auth",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ldap-auth",
+  "upstream_version": "0.0.0"
+}

--- a/librespeed/CHANGELOG.md
+++ b/librespeed/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/librespeed/Dockerfile
+++ b/librespeed/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-librespeed/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-librespeed/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-librespeed/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-librespeed/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-librespeed/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/librespeed/build.json
+++ b/librespeed/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/librespeed:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/librespeed:amd64-latest"
+  }
+}

--- a/librespeed/config.yaml
+++ b/librespeed/config.yaml
@@ -1,0 +1,29 @@
+homeassistant: "2024.1.0"
+name: LibreSpeed
+description: Self-hosted speed test server — lightweight HTML5/JS speed test
+slug: librespeed
+url: https://github.com/linuxserver/docker-librespeed
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/librespeed-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+ports:
+  80/tcp: 8089
+ports_description:
+  80/tcp: LibreSpeed web interface (not required for Ingress)
+ingress: true
+ingress_port: 80
+ingress_stream: true
+panel_admin: false
+panel_icon: mdi:speedometer
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  PASSWORD: "PASSWORD"
+  CUSTOM_RESULTS: false
+  DB_TYPE: "sqlite"
+

--- a/librespeed/updater.json
+++ b/librespeed/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "librespeed",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-librespeed",
+  "upstream_version": "0.0.0"
+}

--- a/lidarr/CHANGELOG.md
+++ b/lidarr/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/lidarr/Dockerfile
+++ b/lidarr/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-lidarr/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-lidarr/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-lidarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-lidarr/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-lidarr/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8686" \
+    HEALTH_URL="/ping"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/lidarr/build.json
+++ b/lidarr/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/lidarr:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/lidarr:amd64-latest"
+  }
+}

--- a/lidarr/config.yaml
+++ b/lidarr/config.yaml
@@ -1,0 +1,103 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description:
+  Music collection manager for Usenet and BitTorrent users. Monitors RSS feeds
+  for new tracks, grabs, sorts, renames, and auto-upgrades quality.
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video11
+  - /dev/video12
+  - /dev/video13
+  - /dev/video14
+  - /dev/video15
+  - /dev/video16
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  - /dev/nvme0n1p2
+  - /dev/nvme0n1p3
+  - /dev/nvme1n1
+  - /dev/nvme1n1p1
+  - /dev/nvme1n1p2
+  - /dev/nvme1n1p3
+  - /dev/nvme2n1
+  - /dev/nvme2n1p1
+  - /dev/nvme2n1p2
+  - /dev/nvme2n3p3
+  - /dev/mmcblk
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_dbus: true
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/lidarr-{arch}
+ingress: true
+ingress_port: 8686
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Lidarr
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/lidarr
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:music-note
+ports:
+  8686/tcp: 8686
+ports_description:
+  8686/tcp: Web interface
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:lidarr-[a-z0-9-]+$)?
+slug: lidarr
+udev: true
+url: https://github.com/lidarr/Lidarr
+version: "1.0.0"
+video: true
+

--- a/lidarr/updater.json
+++ b/lidarr/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "lidarr",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-lidarr",
+  "upstream_version": "0.0.0"
+}

--- a/lychee/CHANGELOG.md
+++ b/lychee/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/lychee/Dockerfile
+++ b/lychee/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-lychee/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-lychee/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-lychee/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-lychee/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-lychee/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8781" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/lychee/build.json
+++ b/lychee/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/lychee:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/lychee:amd64-latest"
+  }
+}

--- a/lychee/config.yaml
+++ b/lychee/config.yaml
@@ -1,0 +1,72 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: Free photo-management tool with a clean interface for uploading, managing, and sharing photos
+environment:
+  ATTACHED_DEVICES_PERMS: "/dev/dri /dev/vchiq /dev/vc-mem /dev/video1? -type c -o -type f"
+homeassistant: 2024.1.0
+icon: icon.png
+image: ghcr.io/rezusnet/lychee-{arch}
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Lychee
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/lychee
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+  pictures_path: /pictures
+  db_connection: sqlite
+  db_host: ""
+  db_port: ""
+  db_username: ""
+  db_password: ""
+  db_database: lychee
+  app_name: Lychee
+  trusted_proxies: ""
+ports:
+  80/tcp: 8781
+ports_description:
+  80/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:universal-[a-z0-9-]+$)?
+  pictures_path: str
+  db_connection: list(sqlite|mysql|pgsql)
+  db_host: str?
+  db_port: str?
+  db_username: str?
+  db_password: password?
+  db_database: str?
+  app_name: str?
+  trusted_proxies: str?
+slug: lychee
+url: https://lycheeorg.github.io/
+version: "1.0.0"
+

--- a/lychee/updater.json
+++ b/lychee/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "lychee",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-lychee",
+  "upstream_version": "0.0.0"
+}

--- a/manyfold/CHANGELOG.md
+++ b/manyfold/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/manyfold/Dockerfile
+++ b/manyfold/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-manyfold/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-manyfold/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-manyfold/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-manyfold/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-manyfold/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3214" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/manyfold/build.json
+++ b/manyfold/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/manyfold:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/manyfold:amd64-latest"
+  }
+}

--- a/manyfold/config.yaml
+++ b/manyfold/config.yaml
@@ -1,0 +1,57 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Self-hosted 3D model file manager for STL/OBJ/3MF files. Organizes, tags,
+  and previews 3D printing models. Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/manyfold-{arch}
+ingress: true
+ingress_port: 3214
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - media:rw
+name: Manyfold
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  database_url: "sqlite3:/config/manyfold.sqlite3"
+  redis_url: ""
+  secret_key_base: ""
+  library_path: /share/manyfold/models
+panel_admin: false
+panel_icon: mdi:cube-outline
+ports:
+  3214/tcp: 3214
+ports_description:
+  3214/tcp: Web Interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  database_url: str?
+  redis_url: str?
+  secret_key_base: password?
+  library_path: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: manyfold
+url: https://manyfold.app
+version: "1.0.0"
+

--- a/manyfold/updater.json
+++ b/manyfold/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "manyfold",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-manyfold",
+  "upstream_version": "0.0.0"
+}

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-mariadb/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-mariadb/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-mariadb/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-mariadb/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-mariadb/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/mariadb/build.json
+++ b/mariadb/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/mariadb:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/mariadb:amd64-latest"
+  }
+}

--- a/mariadb/config.yaml
+++ b/mariadb/config.yaml
@@ -1,0 +1,33 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "MariaDB"
+description: "MySQL-compatible database server for Home Assistant add-ons"
+version: "1.0.0"
+slug: "mariadb"
+url: "https://github.com/linuxserver/docker-mariadb"
+arch:
+  - amd64
+  - aarch64
+startup: "system"
+boot: "auto"
+map:
+  - config:rw
+options:
+  TZ: "Etc/UTC"
+  mysql_root_password: ""
+  mysql_database: ""
+  mysql_user: ""
+  mysql_password: ""
+  remote_sql: ""
+  cli_opts: ""
+  custom_cnf: ""
+schema:
+  TZ: str
+  mysql_root_password: password
+  mysql_database: str?
+  mysql_user: str?
+  mysql_password: password?
+  remote_sql: str?
+  cli_opts: str?
+  custom_cnf: str?
+

--- a/mariadb/updater.json
+++ b/mariadb/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "mariadb",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-mariadb",
+  "upstream_version": "0.0.0"
+}

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/mastodon/Dockerfile
+++ b/mastodon/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-mastodon/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-mastodon/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-mastodon/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-mastodon/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-mastodon/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/mastodon/build.json
+++ b/mastodon/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/mastodon:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/mastodon:amd64-latest"
+  }
+}

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -1,0 +1,41 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: Mastodon
+description: Self-hosted social network server based on ActivityPub
+slug: mastodon
+url: https://github.com/linuxserver/docker-mastodon
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/mastodon-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+ports:
+  80/tcp: 8080
+  443/tcp: 8443
+ports_description:
+  80/tcp: Mastodon web UI (HTTP)
+  443/tcp: Mastodon web UI (HTTPS)
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  LOCAL_DOMAIN: "example.com"
+  SECRET_KEY_BASE: ""
+  OTP_SECRET: ""
+  VAPID_PRIVATE_KEY: ""
+  VAPID_PUBLIC_KEY: ""
+  DB_HOST: "homeassistant"
+  DB_USER: "mastodon"
+  DB_NAME: "mastodon"
+  DB_PASS: ""
+  DB_PORT: 5432
+  REDIS_HOST: "homeassistant"
+  REDIS_PORT: 6379
+  SMTP_SERVER: "mail.example.com"
+  SMTP_PORT: 25
+  SMTP_LOGIN: ""
+  SMTP_PASSWORD: ""
+  SMTP_FROM_ADDRESS: "notifications@example.com"
+

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "mastodon",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-mastodon",
+  "upstream_version": "0.0.0"
+}

--- a/medusa/CHANGELOG.md
+++ b/medusa/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/medusa/Dockerfile
+++ b/medusa/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-medusa/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-medusa/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-medusa/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-medusa/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-medusa/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8081" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/medusa/build.json
+++ b/medusa/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/medusa:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/medusa:amd64-latest"
+  }
+}

--- a/medusa/config.yaml
+++ b/medusa/config.yaml
@@ -1,0 +1,53 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Automatic video library manager for TV shows. Watches for new episodes
+  and handles downloading, sorting, and renaming. Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/medusa-{arch}
+ingress: true
+ingress_port: 8081
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - media:rw
+name: Medusa
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  tv_location: /share/tv
+  downloads_location: /share/downloads
+panel_admin: false
+panel_icon: mdi:television-classic
+ports:
+  8081/tcp: 8081
+ports_description:
+  8081/tcp: Web Interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  tv_location: str
+  downloads_location: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: medusa
+url: https://pymedusa.com
+version: "1.0.0"
+

--- a/medusa/updater.json
+++ b/medusa/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "medusa",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-medusa",
+  "upstream_version": "0.0.0"
+}

--- a/minisatip/CHANGELOG.md
+++ b/minisatip/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/minisatip/Dockerfile
+++ b/minisatip/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-minisatip/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-minisatip/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-minisatip/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-minisatip/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-minisatip/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8875" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/minisatip/build.json
+++ b/minisatip/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/minisatip:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/minisatip:amd64-latest"
+  }
+}

--- a/minisatip/config.yaml
+++ b/minisatip/config.yaml
@@ -1,0 +1,50 @@
+arch:
+  - aarch64
+  - amd64
+description:
+  SAT>IP server for TV tuner cards (DVB-S/S2/T/T2/C/C2/ATSC/ISDB-T).
+  Shares tuners over the network for use with tvheadend, VLC, and other SAT>IP clients.
+  Based on the linuxserver.io image.
+devices:
+  - /dev/dvb
+  - /dev/dvb/adapter0
+  - /dev/dvb/adapter1
+  - /dev/dvb/adapter2
+  - /dev/dvb/adapter3
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/minisatip-{arch}
+init: false
+map:
+  - addon_config:rw
+name: Minisatip
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  run_opts: ""
+panel_admin: false
+panel_icon: mdi:satellite-variant
+ports:
+  8875/tcp: 8875
+  554/tcp: 554
+  1900/udp: 1900
+ports_description:
+  8875/tcp: Status Page WebUI
+  554/tcp: RTSP Streaming Port
+  1900/udp: SSDP Device Discovery
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  run_opts: str?
+slug: minisatip
+url: https://github.com/catalinii/minisatip
+version: "1.0.0"
+

--- a/minisatip/updater.json
+++ b/minisatip/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "minisatip",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-minisatip",
+  "upstream_version": "0.0.0"
+}

--- a/monica/CHANGELOG.md
+++ b/monica/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/monica/Dockerfile
+++ b/monica/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-monica/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-monica/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-monica/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-monica/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-monica/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/monica/build.json
+++ b/monica/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/monica:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/monica:amd64-latest"
+  }
+}

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -1,0 +1,67 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+description:
+  Personal CRM and relationship management tool. Organize contacts,
+  interactions, reminders, and notes about people in your life.
+  Based on the linuxserver.io image.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/monica-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+name: Monica
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  database: MariaDB_addon
+  app_url: "http://localhost"
+  app_disable_signup: true
+panel_admin: false
+panel_icon: mdi:account-heart
+ports:
+  80/tcp: 8091
+  443/tcp: null
+ports_description:
+  80/tcp: HTTP Web Interface
+  443/tcp: HTTPS Web Interface (disabled by default)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  database: list(MariaDB_addon|Mysql_external)
+  DB_HOST: str?
+  DB_PORT: int?
+  DB_USERNAME: str?
+  DB_PASSWORD: password?
+  DB_DATABASE: str?
+  app_url: str?
+  TRUSTED_PROXIES: str?
+  app_disable_signup: bool
+  APP_ENV: list(local|production)?
+  certfile: str?
+  keyfile: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+services:
+  - mysql:want
+slug: monica
+url: https://github.com/monicahq/monica
+version: "1.0.0"
+

--- a/monica/updater.json
+++ b/monica/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "monica",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-monica",
+  "upstream_version": "0.0.0"
+}

--- a/mstream/CHANGELOG.md
+++ b/mstream/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/mstream/Dockerfile
+++ b/mstream/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-mstream/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-mstream/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-mstream/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-mstream/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-mstream/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3300" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/mstream/build.json
+++ b/mstream/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/mstream:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/mstream:amd64-latest"
+  }
+}

--- a/mstream/config.yaml
+++ b/mstream/config.yaml
@@ -1,0 +1,54 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: Personal music streaming server with web UI, playlist management, file explorer, and jukebox mode
+homeassistant: 2024.1.0
+icon: icon.png
+image: ghcr.io/rezusnet/mstream-{arch}
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: mStream
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/mstream
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+  music_path: /music
+ports:
+  3000/tcp: 3300
+ports_description:
+  3000/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:universal-[a-z0-9-]+$)?
+  music_path: str
+slug: mstream
+url: https://mstream.io/
+version: "1.0.0"
+

--- a/mstream/updater.json
+++ b/mstream/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "mstream",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-mstream",
+  "upstream_version": "0.0.0"
+}

--- a/mylar3/CHANGELOG.md
+++ b/mylar3/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/mylar3/Dockerfile
+++ b/mylar3/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-mylar3/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-mylar3/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-mylar3/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-mylar3/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-mylar3/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8090" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/mylar3/build.json
+++ b/mylar3/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/mylar3:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/mylar3:amd64-latest"
+  }
+}

--- a/mylar3/config.yaml
+++ b/mylar3/config.yaml
@@ -1,0 +1,34 @@
+homeassistant: "2024.1.0"
+name: "Mylar3"
+description: "Automated Comic Book downloader (cbr/cbz) for NZB & torrents"
+url: "https://github.com/linuxserver/docker-mylar3"
+arch:
+  - aarch64
+  - amd64
+slug: "mylar3"
+version: "1.0.0"
+webui: "http://[HOST]:[PORT:8090]"
+ingress: true
+ingress_port: 8090
+ingress_stream: true
+panel_icon: "mdi:book-open-page-variant"
+panel_title: "Mylar3"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - media:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+ports:
+  8090/tcp: 8090
+ports_description:
+  8090/tcp: "Mylar3 Web UI"
+

--- a/mylar3/updater.json
+++ b/mylar3/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "mylar3",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-mylar3",
+  "upstream_version": "0.0.0"
+}

--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/netbox/Dockerfile
+++ b/netbox/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-netbox/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-netbox/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-netbox/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-netbox/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-netbox/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/netbox/build.json
+++ b/netbox/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/netbox:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/netbox:amd64-latest"
+  }
+}

--- a/netbox/config.yaml
+++ b/netbox/config.yaml
@@ -1,0 +1,86 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  NetBox IPAM/DCIM — Network documentation and management tool.
+  Tracks IPs, VLANs, circuits, racks, devices, and more.
+  Requires external PostgreSQL and Redis instances.
+homeassistant: 2024.1.0
+host_network: false
+icon: icon.png
+image: ghcr.io/rezusnet/netbox-{arch}
+ingress: true
+ingress_port: 8000
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: NetBox
+options:
+  PUID: 0
+  PGID: 0
+  TZ: ""
+  SUPERUSER_EMAIL: ""
+  SUPERUSER_PASSWORD: ""
+  ALLOWED_HOST: "*"
+  DB_HOST: ""
+  DB_PORT: 5432
+  DB_NAME: netbox
+  DB_USER: netbox
+  DB_PASSWORD: ""
+  REDIS_HOST: ""
+  REDIS_PORT: 6379
+  REDIS_USERNAME: ""
+  REDIS_PASSWORD: ""
+  REDIS_DB_TASK: 0
+  REDIS_DB_CACHE: 1
+  BASE_PATH: ""
+  CSRF_TRUSTED_ORIGINS: ""
+  REMOTE_AUTH_ENABLED: false
+  env_vars: []
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str?
+  SUPERUSER_EMAIL: email
+  SUPERUSER_PASSWORD: password
+  ALLOWED_HOST: str
+  DB_HOST: str
+  DB_PORT: int
+  DB_NAME: str
+  DB_USER: str
+  DB_PASSWORD: password
+  REDIS_HOST: str
+  REDIS_PORT: int
+  REDIS_USERNAME: str?
+  REDIS_PASSWORD: password?
+  REDIS_DB_TASK: int
+  REDIS_DB_CACHE: int
+  BASE_PATH: str?
+  CSRF_TRUSTED_ORIGINS: str?
+  REMOTE_AUTH_ENABLED: bool?
+  REMOTE_AUTH_BACKEND: str?
+  REMOTE_AUTH_HEADER: str?
+  REMOTE_AUTH_AUTO_CREATE_USER: bool?
+  REMOTE_AUTH_DEFAULT_GROUPS: str?
+  REMOTE_AUTH_DEFAULT_PERMISSIONS: str?
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: password?
+  cifsdomain: str?
+slug: netbox
+startup: application
+boot: auto
+url: https://github.com/rezusnet/hassio-addons
+version: "1.0.0"
+

--- a/netbox/updater.json
+++ b/netbox/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "netbox",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-netbox",
+  "upstream_version": "0.0.0"
+}

--- a/nextcloud/CHANGELOG.md
+++ b/nextcloud/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-nextcloud/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-nextcloud/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-nextcloud/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-nextcloud/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-nextcloud/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="443" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/nextcloud/build.json
+++ b/nextcloud/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/nextcloud:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/nextcloud:amd64-latest"
+  }
+}

--- a/nextcloud/config.yaml
+++ b/nextcloud/config.yaml
@@ -1,0 +1,98 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description:
+  Self-hosted productivity platform providing file sync, calendar, contacts,
+  and collaborative document editing. Based on the linuxserver.io image.
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+  NEXTCLOUD_PATH: /data/config/www/nextcloud
+  SKIP_DATA_DIRECTORY_PERMISSION_CHECK: "yes"
+  TRUSTED_PROXIES: "**"
+homeassistant: 2024.1.0
+host_dbus: true
+image: ghcr.io/rezusnet/nextcloud-{arch}
+ingress: true
+ingress_port: 443
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - homeassistant_config:rw
+  - share:rw
+  - media:rw
+  - ssl:rw
+  - backup:rw
+name: Nextcloud
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  data_location: /share/nextcloud
+  trusted_domains: ""
+  certfile: fullchain.pem
+  keyfile: privkey.pem
+  use_own_certs: false
+  enable_thumbnails: true
+  Full_Text_Search: false
+  additional_apps: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_admin: false
+panel_icon: mdi:cloud
+ports:
+  443/tcp: 8099
+  80/tcp: null
+ports_description:
+  443/tcp: HTTPS Web Interface
+  80/tcp: HTTP Web Interface (disabled by default)
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  data_location: str
+  trusted_domains: str?
+  certfile: str
+  keyfile: str
+  use_own_certs: bool
+  enable_thumbnails: bool
+  Full_Text_Search: bool?
+  additional_apps: str?
+  default_phone_region: match(^[A-Z]{2}$)?
+  elasticsearch_server: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  skip_permissions_check: bool?
+  disable_updates: bool?
+services:
+  - mysql:want
+slug: nextcloud
+uart: true
+udev: true
+url: https://nextcloud.com
+version: "1.0.0"
+

--- a/nextcloud/updater.json
+++ b/nextcloud/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "nextcloud",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-nextcloud",
+  "upstream_version": "0.0.0"
+}

--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-nginx/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-nginx/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-nginx/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-nginx/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-nginx/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/nginx/build.json
+++ b/nginx/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/nginx:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/nginx:amd64-latest"
+  }
+}

--- a/nginx/config.yaml
+++ b/nginx/config.yaml
@@ -1,0 +1,33 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Nginx"
+description: "Nginx web server and reverse proxy with PHP support"
+url: "https://github.com/linuxserver/docker-nginx"
+arch:
+  - aarch64
+  - amd64
+slug: "nginx"
+version: "1.0.0"
+webui: "http://[HOST]:[PORT:80]"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  NGINX_AUTORELOAD: false
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  NGINX_AUTORELOAD: bool
+ports:
+  80/tcp: 80
+  443/tcp: 443
+ports_description:
+  80/tcp: "HTTP web server"
+  443/tcp: "HTTPS web server"
+

--- a/nginx/updater.json
+++ b/nginx/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "nginx",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-nginx",
+  "upstream_version": "0.0.0"
+}

--- a/ngircd/CHANGELOG.md
+++ b/ngircd/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ngircd/Dockerfile
+++ b/ngircd/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ngircd/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ngircd/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ngircd/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ngircd/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ngircd/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="6667" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ngircd/build.json
+++ b/ngircd/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ngircd:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ngircd:amd64-latest"
+  }
+}

--- a/ngircd/config.yaml
+++ b/ngircd/config.yaml
@@ -1,0 +1,27 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "ngIRCd"
+description: "Lightweight Internet Relay Chat server for small/private networks"
+url: "https://github.com/linuxserver/docker-ngircd"
+arch:
+  - aarch64
+  - amd64
+slug: "ngircd"
+version: "1.0.0"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+ports:
+  6667/tcp: 6667
+ports_description:
+  6667/tcp: "IRC server port"
+

--- a/ngircd/updater.json
+++ b/ngircd/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ngircd",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ngircd",
+  "upstream_version": "0.0.0"
+}

--- a/nzbhydra2/CHANGELOG.md
+++ b/nzbhydra2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/nzbhydra2/Dockerfile
+++ b/nzbhydra2/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-nzbhydra2/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-nzbhydra2/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-nzbhydra2/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-nzbhydra2/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-nzbhydra2/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="5076" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/nzbhydra2/build.json
+++ b/nzbhydra2/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/nzbhydra2:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/nzbhydra2:amd64-latest"
+  }
+}

--- a/nzbhydra2/config.yaml
+++ b/nzbhydra2/config.yaml
@@ -1,0 +1,31 @@
+homeassistant: "2024.1.0"
+name: NZBHydra2
+description: NZB meta search engine — unified search across multiple NZB indexers
+version: "1.0.0"
+slug: nzbhydra2
+url: https://github.com/linuxserver/docker-nzbhydra2
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/nzbhydra2-{arch}
+ports:
+  5076/tcp: 5076
+ports_description:
+  5076/tcp: NZBHydra2 WebUI
+map:
+  - addon_config:rw
+  - share:rw
+environment:
+  PUID: "0"
+  PGID: "0"
+options:
+  PUID: 0
+  PGID: 0
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str?
+ingress: false
+panel_icon: mdi:search-web
+

--- a/nzbhydra2/updater.json
+++ b/nzbhydra2/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "nzbhydra2",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-nzbhydra2",
+  "upstream_version": "0.0.0"
+}

--- a/obsidian/CHANGELOG.md
+++ b/obsidian/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/obsidian/Dockerfile
+++ b/obsidian/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-obsidian/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-obsidian/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-obsidian/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-obsidian/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-obsidian/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3001" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/obsidian/build.json
+++ b/obsidian/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/obsidian:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/obsidian:amd64-latest"
+  }
+}

--- a/obsidian/config.yaml
+++ b/obsidian/config.yaml
@@ -1,0 +1,36 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Obsidian"
+description: "Knowledge base/note-taking app accessible via web desktop"
+url: "https://github.com/linuxserver/docker-obsidian"
+arch:
+  - aarch64
+  - amd64
+slug: "obsidian"
+version: "1.0.0"
+webui: "https://[HOST]:[PORT:3001]"
+ingress: false
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CUSTOM_USER: ""
+  PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CUSTOM_USER: str
+  PASSWORD: password
+ports:
+  3000/tcp: null
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: "Obsidian desktop GUI (HTTP — must be proxied)"
+  3001/tcp: "Obsidian desktop GUI (HTTPS)"
+

--- a/obsidian/updater.json
+++ b/obsidian/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "obsidian",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-obsidian",
+  "upstream_version": "0.0.0"
+}

--- a/ombi/CHANGELOG.md
+++ b/ombi/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ombi/Dockerfile
+++ b/ombi/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ombi/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ombi/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ombi/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ombi/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ombi/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ombi/build.json
+++ b/ombi/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ombi:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ombi:amd64-latest"
+  }
+}

--- a/ombi/config.yaml
+++ b/ombi/config.yaml
@@ -1,0 +1,63 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: Media request management system. Allows users to request movies/TV shows for Plex/Emby with user management and notifications.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/ombi-{arch}
+ingress: true
+ingress_port: 3579
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Ombi
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/ombi
+  TZ: ""
+  BASE_URL: "/"
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+  panel_icon: mdi:movie-open-plus
+ports:
+  3579/tcp: 3579
+ports_description:
+  3579/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  BASE_URL: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:ombi-[a-z0-9-]+$)?
+slug: ombi
+url: https://ombi.io
+version: "1.0.0"
+webui: http://[HOST]:[PORT:3579]
+

--- a/ombi/updater.json
+++ b/ombi/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ombi",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ombi",
+  "upstream_version": "0.0.0"
+}

--- a/openssh-server/CHANGELOG.md
+++ b/openssh-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/openssh-server/Dockerfile
+++ b/openssh-server/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-openssh-server/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-openssh-server/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-openssh-server/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-openssh-server/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-openssh-server/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="2222" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/openssh-server/build.json
+++ b/openssh-server/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/openssh-server:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/openssh-server:amd64-latest"
+  }
+}

--- a/openssh-server/config.yaml
+++ b/openssh-server/config.yaml
@@ -1,0 +1,39 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "OpenSSH Server"
+description: "Sandboxed SSH server for secure remote access"
+url: "https://github.com/linuxserver/docker-openssh-server"
+arch:
+  - aarch64
+  - amd64
+slug: "openssh-server"
+version: "1.0.0"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - share:rw
+  - media:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  USER_NAME: "linuxserver.io"
+  PUBLIC_KEY: ""
+  PASSWORD_ACCESS: false
+  USER_PASSWORD: ""
+  SUDO_ACCESS: false
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  USER_NAME: str
+  PUBLIC_KEY: str
+  PASSWORD_ACCESS: bool
+  USER_PASSWORD: password
+  SUDO_ACCESS: bool
+ports:
+  2222/tcp: 2222
+ports_description:
+  2222/tcp: "SSH server port"
+

--- a/openssh-server/updater.json
+++ b/openssh-server/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "openssh-server",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-openssh-server",
+  "upstream_version": "0.0.0"
+}

--- a/openvscode-server/CHANGELOG.md
+++ b/openvscode-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/openvscode-server/Dockerfile
+++ b/openvscode-server/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-openvscode-server/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-openvscode-server/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-openvscode-server/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-openvscode-server/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-openvscode-server/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/openvscode-server/build.json
+++ b/openvscode-server/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/openvscode-server:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/openvscode-server:amd64-latest"
+  }
+}

--- a/openvscode-server/config.yaml
+++ b/openvscode-server/config.yaml
@@ -1,0 +1,38 @@
+homeassistant: "2024.1.0"
+name: "OpenVSCode Server"
+description: "VS Code server accessible through a web browser"
+url: "https://github.com/linuxserver/docker-openvscode-server"
+arch:
+  - aarch64
+  - amd64
+slug: "openvscode-server"
+version: "1.0.0"
+webui: "http://[HOST]:[PORT:3000]"
+ingress: true
+ingress_port: 3000
+ingress_stream: true
+panel_icon: "mdi:microsoft-visual-studio-code"
+panel_title: "VS Code"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - share:rw
+  - media:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CONNECTION_TOKEN: ""
+  SUDO_PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CONNECTION_TOKEN: password
+  SUDO_PASSWORD: password
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: "VS Code Web UI"
+

--- a/openvscode-server/updater.json
+++ b/openvscode-server/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "openvscode-server",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-openvscode-server",
+  "upstream_version": "0.0.0"
+}

--- a/oscam/CHANGELOG.md
+++ b/oscam/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/oscam/Dockerfile
+++ b/oscam/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-oscam/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-oscam/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-oscam/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-oscam/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-oscam/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8888" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/oscam/build.json
+++ b/oscam/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/oscam:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/oscam:amd64-latest"
+  }
+}

--- a/oscam/config.yaml
+++ b/oscam/config.yaml
@@ -1,0 +1,34 @@
+homeassistant: "2024.1.0"
+name: "OSCam"
+description: "Open Source Conditional Access Module for TV card descrambling"
+url: "https://github.com/linuxserver/docker-oscam"
+arch:
+  - aarch64
+  - amd64
+slug: "oscam"
+version: "1.0.0"
+webui: "http://[HOST]:[PORT:8888]"
+ingress: true
+ingress_port: 8888
+panel_icon: "mdi:television-classic"
+panel_title: "OSCam"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+devices:
+  - /dev/ttyUSB0
+  - /dev/bus/usb
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+ports:
+  8888/tcp: 8888
+ports_description:
+  8888/tcp: "OSCam Web UI"
+

--- a/oscam/updater.json
+++ b/oscam/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "oscam",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-oscam",
+  "upstream_version": "0.0.0"
+}

--- a/overseerr/CHANGELOG.md
+++ b/overseerr/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/overseerr/Dockerfile
+++ b/overseerr/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-overseerr/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-overseerr/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-overseerr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-overseerr/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-overseerr/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/overseerr/build.json
+++ b/overseerr/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/overseerr:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/overseerr:amd64-latest"
+  }
+}

--- a/overseerr/config.yaml
+++ b/overseerr/config.yaml
@@ -1,0 +1,61 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: Request management and media discovery platform for Plex/Jellyfin with a beautiful web UI.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/overseerr-{arch}
+ingress: true
+ingress_port: 5055
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Overseerr
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/overseerr
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+  panel_icon: mdi:movie-search
+ports:
+  5055/tcp: 5055
+ports_description:
+  5055/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:overseerr-[a-z0-9-]+$)?
+slug: overseerr
+url: https://overseerr.dev
+version: "1.0.0"
+webui: http://[HOST]:[PORT:5055]
+

--- a/overseerr/updater.json
+++ b/overseerr/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "overseerr",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-overseerr",
+  "upstream_version": "0.0.0"
+}

--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/pairdrop/build.json
+++ b/pairdrop/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/pairdrop:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/pairdrop:amd64-latest"
+  }
+}

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -1,0 +1,28 @@
+homeassistant: "2024.1.0"
+name: PairDrop
+description: Local file sharing in the browser — an AirDrop alternative
+slug: pairdrop
+url: https://github.com/linuxserver/docker-pairdrop
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/pairdrop-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: PairDrop web interface
+ingress: true
+ingress_port: 3000
+panel_admin: false
+panel_icon: mdi:share-variant
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  RATE_LIMIT: false
+  WS_FALLBACK: false
+  DEBUG_MODE: false
+

--- a/pairdrop/updater.json
+++ b/pairdrop/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "pairdrop",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-pairdrop",
+  "upstream_version": "0.0.0"
+}

--- a/phpmyadmin/CHANGELOG.md
+++ b/phpmyadmin/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-phpmyadmin/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-phpmyadmin/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-phpmyadmin/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-phpmyadmin/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-phpmyadmin/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/phpmyadmin/build.json
+++ b/phpmyadmin/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/phpmyadmin:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/phpmyadmin:amd64-latest"
+  }
+}

--- a/phpmyadmin/config.yaml
+++ b/phpmyadmin/config.yaml
@@ -1,0 +1,35 @@
+homeassistant: "2024.1.0"
+name: "phpMyAdmin"
+description: "Web interface for MySQL/MariaDB database management"
+url: "https://github.com/linuxserver/docker-phpmyadmin"
+arch:
+  - aarch64
+  - amd64
+slug: "phpmyadmin"
+version: "1.0.0"
+webui: "http://[HOST]:[PORT:80]"
+ingress: true
+ingress_port: 80
+panel_icon: "mdi:database"
+panel_title: "phpMyAdmin"
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  PMA_ARBITRARY: true
+  PMA_ABSOLUTE_URI: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  PMA_ARBITRARY: bool
+  PMA_ABSOLUTE_URI: str?
+ports:
+  80/tcp: 80
+ports_description:
+  80/tcp: "phpMyAdmin web frontend"
+

--- a/phpmyadmin/updater.json
+++ b/phpmyadmin/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "phpmyadmin",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-phpmyadmin",
+  "upstream_version": "0.0.0"
+}

--- a/piper/CHANGELOG.md
+++ b/piper/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-piper/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-piper/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-piper/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-piper/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-piper/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="10200" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/piper/build.json
+++ b/piper/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/piper:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/piper:amd64-latest"
+  }
+}

--- a/piper/config.yaml
+++ b/piper/config.yaml
@@ -1,0 +1,65 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Fast, local neural text-to-speech engine via Wyoming protocol.
+  Provides Piper TTS for Home Assistant Assist voice pipelines.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/piper-{arch}
+ingress: false
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: Piper TTS
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/piper
+  TZ: ""
+  PIPER_VOICE: "en_US-lessac-medium"
+  PIPER_LENGTH: 1.0
+  PIPER_NOISE: 0.667
+  PIPER_NOISEW: 0.333
+  PIPER_SPEAKER: 0
+  LOCAL_ONLY: false
+  NO_STREAMING: false
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:speaker-message
+ports:
+  10200/tcp: 10200
+ports_description:
+  10200/tcp: Wyoming protocol connection port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  PIPER_VOICE: str
+  PIPER_LENGTH: float
+  PIPER_NOISE: float
+  PIPER_NOISEW: float
+  PIPER_SPEAKER: int
+  LOCAL_ONLY: bool
+  NO_STREAMING: bool
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: piper
+udev: true
+url: https://github.com/rhasspy/wyoming-piper
+version: "1.0.0"
+

--- a/piper/updater.json
+++ b/piper/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "piper",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-piper",
+  "upstream_version": "0.0.0"
+}

--- a/piwigo/CHANGELOG.md
+++ b/piwigo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/piwigo/Dockerfile
+++ b/piwigo/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-piwigo/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-piwigo/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-piwigo/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-piwigo/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-piwigo/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8780" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/piwigo/build.json
+++ b/piwigo/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/piwigo:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/piwigo:amd64-latest"
+  }
+}

--- a/piwigo/config.yaml
+++ b/piwigo/config.yaml
@@ -1,0 +1,66 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description: Photo gallery software for the web with powerful publishing and management features
+environment:
+  ATTACHED_DEVICES_PERMS: "/dev/dri /dev/vchiq /dev/vc-mem /dev/video1? -type c -o -type f"
+homeassistant: 2024.1.0
+icon: icon.png
+image: ghcr.io/rezusnet/piwigo-{arch}
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Piwigo
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/piwigo
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+  gallery_path: /gallery
+  db_host: ""
+  db_port: "3306"
+  db_username: ""
+  db_password: ""
+  db_database: piwigo
+ports:
+  80/tcp: 8780
+ports_description:
+  80/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:universal-[a-z0-9-]+$)?
+  gallery_path: str
+  db_host: str?
+  db_port: str?
+  db_username: str?
+  db_password: password?
+  db_database: str?
+slug: piwigo
+url: http://piwigo.org
+version: "1.0.0"
+

--- a/piwigo/updater.json
+++ b/piwigo/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "piwigo",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-piwigo",
+  "upstream_version": "0.0.0"
+}

--- a/planka/CHANGELOG.md
+++ b/planka/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/planka/Dockerfile
+++ b/planka/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-planka/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-planka/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-planka/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-planka/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-planka/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/planka/build.json
+++ b/planka/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/planka:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/planka:amd64-latest"
+  }
+}

--- a/planka/config.yaml
+++ b/planka/config.yaml
@@ -1,0 +1,71 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Planka — open source Trello-like kanban board for project tracking.
+  Features real-time updates, card assignments, labels, due dates, and more.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/planka-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: Planka
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/planka
+  TZ: ""
+  BASE_URL: ""
+  DATABASE_URL: ""
+  DEFAULT_ADMIN_EMAIL: ""
+  DEFAULT_ADMIN_USERNAME: ""
+  DEFAULT_ADMIN_PASSWORD: ""
+  DEFAULT_ADMIN_NAME: ""
+  SECRET_KEY: ""
+  TRUST_PROXY: false
+  DEFAULT_LANGUAGE: "en-US"
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:view-dashboard-variant-outline
+ports:
+  1337/tcp: null
+ports_description:
+  1337/tcp: Planka web UI (optional, not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  BASE_URL: str
+  DATABASE_URL: str
+  DEFAULT_ADMIN_EMAIL: str
+  DEFAULT_ADMIN_USERNAME: str
+  DEFAULT_ADMIN_PASSWORD: password
+  DEFAULT_ADMIN_NAME: str
+  SECRET_KEY: password
+  TRUST_PROXY: bool
+  DEFAULT_LANGUAGE: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: planka
+udev: true
+url: https://github.com/plankanban/planka
+version: "1.0.0"
+

--- a/planka/updater.json
+++ b/planka/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "planka",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-planka",
+  "upstream_version": "0.0.0"
+}

--- a/plex/CHANGELOG.md
+++ b/plex/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-plex/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-plex/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-plex/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-plex/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-plex/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="32400" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/plex/build.json
+++ b/plex/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/plex:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/plex:amd64-latest"
+  }
+}

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -1,0 +1,79 @@
+homeassistant: "2024.1.0"
+name: Plex
+description: >
+  Plex Media Server — organizes video, music and photos from personal
+  media libraries and streams them to smart TVs, streaming boxes and
+  mobile devices.
+slug: plex
+url: https://github.com/linuxserver/docker-plex
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/plex-{arch}
+version: "1.0.0"
+init: false
+
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: Etc/UTC
+  VERSION: docker
+  PLEX_CLAIM: ""
+  env_vars: []
+
+schema:
+  PUID: int
+  PGID: int
+  TZ: str?
+  VERSION: str?
+  PLEX_CLAIM: str?
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+
+host_network: true
+
+ports:
+  32400/tcp: 32400
+  1900/udp: 1900
+  5353/udp: 5353
+  8324/tcp: 8324
+  32410/udp: 32410
+  32412/udp: 32412
+  32413/udp: 32413
+  32414/udp: 32414
+  32469/tcp: 32469
+
+ports_description:
+  32400/tcp: "Plex Media Server Web Interface"
+  1900/udp: "Plex DLNA Server"
+  5353/udp: "mDNS discovery"
+  8324/tcp: "Plex for Roku via Plex Companion"
+  32410/udp: "GDM network discovery"
+  32412/udp: "GDM network discovery"
+  32413/udp: "GDM network discovery"
+  32414/udp: "GDM network discovery"
+  32469/tcp: "Plex DLNA Server HTTP"
+
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+
+environment:
+  VERSION: docker
+  HOME: /config
+
+webui: "http://[HOST]:[PORT:32400]/web"
+ingress: false
+panel_icon: mdi:plex
+panel_admin: false
+
+backup_exclude:
+  - "**/Cache/**"
+  - "**/Plug-in Support/Caches/**"
+  - "**/Logs/**"
+  - "**/Crash Reports/**"
+  - "**/Diagnostics/**"
+

--- a/plex/updater.json
+++ b/plex/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "plex",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-plex",
+  "upstream_version": "0.0.0"
+}

--- a/projectsend/CHANGELOG.md
+++ b/projectsend/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/projectsend/Dockerfile
+++ b/projectsend/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-projectsend/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-projectsend/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-projectsend/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-projectsend/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-projectsend/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/projectsend/build.json
+++ b/projectsend/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/projectsend:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/projectsend:amd64-latest"
+  }
+}

--- a/projectsend/config.yaml
+++ b/projectsend/config.yaml
@@ -1,0 +1,54 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  ProjectSend — self-hosted file sharing with client upload/download.
+  Upload files and assign them to specific clients securely and privately.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/projectsend-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - ssl
+name: ProjectSend
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/projectsend
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:file-upload-outline
+ports:
+  80/tcp: null
+ports_description:
+  80/tcp: HTTP web interface (optional, not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: projectsend
+udev: true
+url: http://www.projectsend.org
+version: "1.0.0"
+

--- a/projectsend/updater.json
+++ b/projectsend/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "projectsend",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-projectsend",
+  "upstream_version": "0.0.0"
+}

--- a/pwndrop/CHANGELOG.md
+++ b/pwndrop/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/pwndrop/Dockerfile
+++ b/pwndrop/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pwndrop/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pwndrop/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pwndrop/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pwndrop/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pwndrop/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/pwndrop/build.json
+++ b/pwndrop/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/pwndrop:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/pwndrop:amd64-latest"
+  }
+}

--- a/pwndrop/config.yaml
+++ b/pwndrop/config.yaml
@@ -1,0 +1,55 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Pwndrop — self-hosted file upload and URL shortening service.
+  Share files securely over HTTP and WebDAV with custom short URLs.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/pwndrop-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: Pwndrop
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/pwndrop
+  TZ: ""
+  SECRET_PATH: "/pwndrop"
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:share-variant-outline
+ports:
+  8080/tcp: null
+ports_description:
+  8080/tcp: HTTP web GUI (optional, not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  SECRET_PATH: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: pwndrop
+udev: true
+url: https://github.com/kgretzky/pwndrop
+version: "1.0.0"
+

--- a/pwndrop/updater.json
+++ b/pwndrop/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "pwndrop",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-pwndrop",
+  "upstream_version": "0.0.0"
+}

--- a/pydio-cells/CHANGELOG.md
+++ b/pydio-cells/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/pydio-cells/Dockerfile
+++ b/pydio-cells/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pydio-cells/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pydio-cells/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pydio-cells/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pydio-cells/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pydio-cells/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/pydio-cells/build.json
+++ b/pydio-cells/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/pydio-cells:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/pydio-cells:amd64-latest"
+  }
+}

--- a/pydio-cells/config.yaml
+++ b/pydio-cells/config.yaml
@@ -1,0 +1,56 @@
+arch:
+  - aarch64
+  - amd64
+description:
+  Pydio Cells — enterprise file sharing and collaboration platform with granular
+  access control, versioning, and workflow automation.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/pydio-cells-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+map:
+  - addon_config:rw
+  - share:rw
+icon: icon.png
+name: Pydio Cells
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  EXTERNALURL: ""
+  SERVER_IP: ""
+  data_location: /config
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:cloud-upload
+ports:
+  8080/tcp: 8080
+ports_description:
+  8080/tcp: HTTPS web interface & API
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  EXTERNALURL: str?
+  SERVER_IP: str?
+  data_location: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: pydio-cells
+url: https://pydio.com
+version: "1.0.0"
+

--- a/pydio-cells/updater.json
+++ b/pydio-cells/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "pydio-cells",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-pydio-cells",
+  "upstream_version": "0.0.0"
+}

--- a/pyload-ng/CHANGELOG.md
+++ b/pyload-ng/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/pyload-ng/Dockerfile
+++ b/pyload-ng/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pyload-ng/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pyload-ng/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pyload-ng/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pyload-ng/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pyload-ng/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/pyload-ng/build.json
+++ b/pyload-ng/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/pyload-ng:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/pyload-ng:amd64-latest"
+  }
+}

--- a/pyload-ng/config.yaml
+++ b/pyload-ng/config.yaml
@@ -1,0 +1,55 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  pyLoad NG — free and open source download manager for one-click hosters.
+  Lightweight, extensible, and fully manageable via web interface.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/pyload-ng-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: pyLoad NG
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/pyload-ng
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:download-circle-outline
+ports:
+  8000/tcp: null
+  9666/tcp: null
+ports_description:
+  8000/tcp: HTTP web interface (optional, not required for Ingress)
+  9666/tcp: Click'n'Load port (optional)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: pyload-ng
+udev: true
+url: https://pyload.net
+version: "1.0.0"
+

--- a/pyload-ng/updater.json
+++ b/pyload-ng/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "pyload-ng",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-pyload-ng",
+  "upstream_version": "0.0.0"
+}

--- a/raneto/CHANGELOG.md
+++ b/raneto/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/raneto/Dockerfile
+++ b/raneto/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-raneto/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-raneto/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-raneto/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-raneto/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-raneto/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/raneto/build.json
+++ b/raneto/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/raneto:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/raneto:amd64-latest"
+  }
+}

--- a/raneto/config.yaml
+++ b/raneto/config.yaml
@@ -1,0 +1,53 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Raneto — markdown-powered knowledge base and wiki platform.
+  Create searchable documentation and FAQs using static Markdown files.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/raneto-{arch}
+ingress: true
+ingress_port: 8080
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: Raneto
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/raneto
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:book-open-page-variant-outline
+ports:
+  3000/tcp: null
+ports_description:
+  3000/tcp: HTTP web interface (optional, not required for Ingress)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: raneto
+udev: true
+url: http://raneto.com
+version: "1.0.0"
+

--- a/raneto/updater.json
+++ b/raneto/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "raneto",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-raneto",
+  "upstream_version": "0.0.0"
+}

--- a/readarr/CHANGELOG.md
+++ b/readarr/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/readarr/Dockerfile
+++ b/readarr/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-readarr/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-readarr/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-readarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-readarr/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-readarr/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8787" \
+    HEALTH_URL="/ping"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/readarr/build.json
+++ b/readarr/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/readarr:arm64v8-develop",
+    "amd64": "lscr.io/linuxserver/readarr:amd64-develop"
+  }
+}

--- a/readarr/config.yaml
+++ b/readarr/config.yaml
@@ -1,0 +1,103 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description:
+  Book manager and automation (Sonarr for Ebooks). Monitors RSS feeds for new
+  releases, grabs, sorts, renames, and auto-upgrades book quality.
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video11
+  - /dev/video12
+  - /dev/video13
+  - /dev/video14
+  - /dev/video15
+  - /dev/video16
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  - /dev/nvme0n1p2
+  - /dev/nvme0n1p3
+  - /dev/nvme1n1
+  - /dev/nvme1n1p1
+  - /dev/nvme1n1p2
+  - /dev/nvme1n1p3
+  - /dev/nvme2n1
+  - /dev/nvme2n1p1
+  - /dev/nvme2n1p2
+  - /dev/nvme2n3p3
+  - /dev/mmcblk
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+host_dbus: true
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/readarr-{arch}
+ingress: true
+ingress_port: 8787
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+name: Readarr
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/readarr
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  DOCKER_MODS: []
+panel_icon: mdi:book-open-page-variant
+ports:
+  8787/tcp: 8787
+ports_description:
+  8787/tcp: Web interface
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:readarr-[a-z0-9-]+$)?
+slug: readarr
+udev: true
+url: https://github.com/Readarr/Readarr
+version: "1.0.0"
+video: true
+

--- a/readarr/updater.json
+++ b/readarr/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "readarr",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-readarr",
+  "upstream_version": "0.0.0"
+}

--- a/resilio-sync/CHANGELOG.md
+++ b/resilio-sync/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/resilio-sync/Dockerfile
+++ b/resilio-sync/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-resilio-sync/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-resilio-sync/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-resilio-sync/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-resilio-sync/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-resilio-sync/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="0" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/resilio-sync/build.json
+++ b/resilio-sync/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/resilio-sync:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/resilio-sync:amd64-latest"
+  }
+}

--- a/resilio-sync/config.yaml
+++ b/resilio-sync/config.yaml
@@ -1,0 +1,57 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Resilio Sync — fast P2P file synchronization using BitTorrent protocol.
+  Sync files and folders between all your devices without cloud services.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/resilio-sync-{arch}
+ingress: true
+ingress_port: 55555
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - media:rw
+  - backup:rw
+name: Resilio Sync
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/resilio-sync
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:sync-circle
+ports:
+  8888/tcp: null
+  55555/tcp: 55555
+ports_description:
+  8888/tcp: WebUI for configuration (optional, not required for Ingress)
+  55555/tcp: Sync listening port (required for P2P connections)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: resilio-sync
+udev: true
+url: https://www.resilio.com/individuals/
+version: "1.0.0"
+

--- a/resilio-sync/updater.json
+++ b/resilio-sync/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "resilio-sync",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-resilio-sync",
+  "upstream_version": "0.0.0"
+}

--- a/rsnapshot/CHANGELOG.md
+++ b/rsnapshot/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/rsnapshot/Dockerfile
+++ b/rsnapshot/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-rsnapshot/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-rsnapshot/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-rsnapshot/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-rsnapshot/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-rsnapshot/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/rsnapshot/build.json
+++ b/rsnapshot/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/rsnapshot:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/rsnapshot:amd64-latest"
+  }
+}

--- a/rsnapshot/config.yaml
+++ b/rsnapshot/config.yaml
@@ -1,0 +1,51 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  rsnapshot — filesystem snapshot utility based on rsync.
+  Periodic local and remote backups using hard links for space efficiency.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/rsnapshot-{arch}
+ingress: false
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+  - backup:rw
+  - homeassistant_config:ro
+  - media:ro
+  - ssl:ro
+name: rsnapshot
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /config/rsnapshot
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:backup-restore
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: rsnapshot
+udev: true
+url: http://www.rsnapshot.org
+version: "1.0.0"
+

--- a/rsnapshot/updater.json
+++ b/rsnapshot/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "rsnapshot",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-rsnapshot",
+  "upstream_version": "0.0.0"
+}

--- a/sealskin/CHANGELOG.md
+++ b/sealskin/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/sealskin/Dockerfile
+++ b/sealskin/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-sealskin/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-sealskin/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-sealskin/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-sealskin/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-sealskin/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8443" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/sealskin/build.json
+++ b/sealskin/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/sealskin:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/sealskin:amd64-latest"
+  }
+}

--- a/sealskin/config.yaml
+++ b/sealskin/config.yaml
@@ -1,0 +1,31 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "SealSkin"
+description: "Self-hosted platform for streaming containerized desktop apps to browser"
+url: "https://github.com/linuxserver/docker-sealskin"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/sealskin-{arch}
+ports:
+  8443/tcp: 8443
+  8000/tcp: 8000
+ports_description:
+  8443/tcp: "HTTPS Sessions and API communication"
+  8000/tcp: "HTTP Fallback API communication (optional)"
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  HOST_URL: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  HOST_URL: str?
+
+slug: sealskin
+version: "1.0.0"

--- a/sealskin/updater.json
+++ b/sealskin/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "sealskin",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-sealskin",
+  "upstream_version": "0.0.0"
+}

--- a/sickgear/CHANGELOG.md
+++ b/sickgear/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/sickgear/Dockerfile
+++ b/sickgear/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-sickgear/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-sickgear/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-sickgear/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-sickgear/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-sickgear/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8081" \
+    HEALTH_URL="/home"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/sickgear/build.json
+++ b/sickgear/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/sickgear:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/sickgear:amd64-latest"
+  }
+}

--- a/sickgear/config.yaml
+++ b/sickgear/config.yaml
@@ -1,0 +1,57 @@
+arch:
+  - aarch64
+  - amd64
+description:
+  SickGear — TV show manager that tracks episodes, finds new releases via indexers,
+  and interfaces with download clients for automated episode acquisition.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/sickgear-{arch}
+ingress: true
+ingress_port: 8081
+ingress_stream: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+icon: icon.png
+name: SickGear
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  TZ: ""
+  data_location: /config
+  tv_folder: /share/sickgear/tv
+  downloads_folder: /share/sickgear/downloads
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:television-classic
+ports:
+  8081/tcp: 8081
+ports_description:
+  8081/tcp: SickGear Web UI
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  TZ: str?
+  data_location: str
+  tv_folder: str
+  downloads_folder: str
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: sickgear
+url: https://github.com/sickgear/sickgear
+version: "1.0.0"
+

--- a/sickgear/updater.json
+++ b/sickgear/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "sickgear",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-sickgear",
+  "upstream_version": "0.0.0"
+}

--- a/smokeping/CHANGELOG.md
+++ b/smokeping/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/smokeping/Dockerfile
+++ b/smokeping/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-smokeping/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-smokeping/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-smokeping/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-smokeping/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-smokeping/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/smokeping/smokeping.cgi"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/smokeping/build.json
+++ b/smokeping/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/smokeping:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/smokeping:amd64-latest"
+  }
+}

--- a/smokeping/config.yaml
+++ b/smokeping/config.yaml
@@ -1,0 +1,54 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  SmokePing tracks network latency over time. It measures latency to configured
+  targets using multiple probe types (fping, tcpping, curl, DNS) and renders
+  interactive graphs. Supports master/slave mode for distributed monitoring.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/smokeping-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+ingress_entry: smokeping/smokeping.cgi
+map:
+  - addon_config:rw
+icon: icon.png
+name: SmokePing
+options:
+  env_vars: []
+  TZ: ""
+  MASTER_URL: ""
+  SHARED_SECRET: ""
+  CACHE_DIR: /tmp
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  panel_icon: mdi:access-point-network
+ports:
+  80/tcp: 80
+ports_description:
+  80/tcp: Web UI (ingress enabled)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  MASTER_URL: str?
+  SHARED_SECRET: password?
+  CACHE_DIR: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  panel_icon: str
+slug: smokeping
+url: https://oss.oetiker.ch/smokeping/
+version: "1.0.0"
+

--- a/smokeping/updater.json
+++ b/smokeping/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "smokeping",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-smokeping",
+  "upstream_version": "0.0.0"
+}

--- a/speedtest-tracker/CHANGELOG.md
+++ b/speedtest-tracker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/speedtest-tracker/Dockerfile
+++ b/speedtest-tracker/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-speedtest-tracker/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-speedtest-tracker/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-speedtest-tracker/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-speedtest-tracker/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-speedtest-tracker/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="80" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/speedtest-tracker/build.json
+++ b/speedtest-tracker/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/speedtest-tracker:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/speedtest-tracker:amd64-latest"
+  }
+}

--- a/speedtest-tracker/config.yaml
+++ b/speedtest-tracker/config.yaml
@@ -1,0 +1,66 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Speedtest Tracker runs regular internet speed tests against Ookla's Speedtest
+  service and graphs results over time. Track download/upload speeds and latency
+  to verify ISP performance.
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/speedtest-tracker-{arch}
+ingress: true
+ingress_port: 80
+ingress_stream: true
+map:
+  - addon_config:rw
+icon: icon.png
+name: Speedtest Tracker
+options:
+  env_vars: []
+  TZ: ""
+  APP_KEY: ""
+  APP_URL: ""
+  DB_CONNECTION: sqlite
+  SPEEDTEST_SCHEDULE: "0 */6 * * *"
+  SPEEDTEST_SERVERS: ""
+  DISPLAY_TIMEZONE: ""
+  PRUNE_RESULTS_OLDER_THAN: 0
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+  panel_icon: mdi:speedometer
+ports:
+  80/tcp: 80
+ports_description:
+  80/tcp: Web UI (ingress enabled)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  TZ: str?
+  APP_KEY: password
+  APP_URL: str?
+  DB_CONNECTION: list(sqlite|pgsql|mysql)
+  SPEEDTEST_SCHEDULE: str?
+  SPEEDTEST_SERVERS: str?
+  DISPLAY_TIMEZONE: str?
+  PRUNE_RESULTS_OLDER_THAN: int?
+  DB_HOST: str?
+  DB_PORT: int?
+  DB_DATABASE: str?
+  DB_USERNAME: str?
+  DB_PASSWORD: password?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+  panel_icon: str
+slug: speedtest-tracker
+url: https://github.com/alexjustesen/speedtest-tracker
+version: "1.0.0"
+

--- a/speedtest-tracker/updater.json
+++ b/speedtest-tracker/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "speedtest-tracker",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-speedtest-tracker",
+  "upstream_version": "0.0.0"
+}

--- a/spotube/CHANGELOG.md
+++ b/spotube/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/spotube/Dockerfile
+++ b/spotube/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-spotube/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-spotube/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-spotube/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-spotube/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-spotube/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/spotube/build.json
+++ b/spotube/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/spotube:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/spotube:amd64-latest"
+  }
+}

--- a/spotube/config.yaml
+++ b/spotube/config.yaml
@@ -1,0 +1,32 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Spotube"
+description: "Lightweight open-source Spotify client via web browser (Selkies/KasmVNC)"
+url: "https://github.com/linuxserver/docker-spotube"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/spotube-{arch}
+ports:
+  3000/tcp: 3000
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: "Spotube desktop GUI (HTTP, must be proxied)"
+  3001/tcp: "Spotube desktop GUI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CUSTOM_USER: ""
+  PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CUSTOM_USER: str?
+  PASSWORD: str?
+
+slug: spotube
+version: "1.0.0"

--- a/spotube/updater.json
+++ b/spotube/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "spotube",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-spotube",
+  "upstream_version": "0.0.0"
+}

--- a/swag/CHANGELOG.md
+++ b/swag/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/swag/Dockerfile
+++ b/swag/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-swag/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-swag/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-swag/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-swag/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-swag/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="443" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/swag/build.json
+++ b/swag/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/swag:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/swag:amd64-latest"
+  }
+}

--- a/swag/config.yaml
+++ b/swag/config.yaml
@@ -1,0 +1,54 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: SWAG
+description: Secure Web Application Gateway - Nginx reverse proxy with built-in certbot, fail2ban, and geoip2
+slug: swag
+url: https://github.com/linuxserver/docker-swag
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/swag-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+ports:
+  443/tcp: 443
+  80/tcp: 80
+ports_description:
+  443/tcp: HTTPS port
+  80/tcp: HTTP port (required for HTTP validation and HTTP->HTTPS redirect)
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  URL: "example.com"
+  VALIDATION: "http"
+  SUBDOMAINS: "www"
+  CERTPROVIDER: ""
+  DNSPLUGIN: "cloudflare"
+  PROPAGATION: ""
+  EMAIL: ""
+  ONLY_SUBDOMAINS: false
+  EXTRA_DOMAINS: ""
+  STAGING: false
+  DISABLE_F2B: false
+  SWAG_AUTORELOAD: false
+  SWAG_AUTORELOAD_WATCHLIST: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  URL: str
+  VALIDATION: list(http|dns)
+  SUBDOMAINS: str?
+  CERTPROVIDER: str?
+  DNSPLUGIN: list(|acmedns|aliyun|azure|bunny|cloudflare|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|do|domeneshop|dreamhost|duckdns|dynu|freedns|gandi|gehirn|glesys|godaddy|google|he|hetzner|hetzner-cloud|infomaniak|inwx|ionos|linode|loopia|luadns|namecheap|netcup|njalla|nsone|ovh|porkbun|rfc2136|route53|sakuracloud|standalone|transip|vultr)?
+  PROPAGATION: str?
+  EMAIL: str?
+  ONLY_SUBDOMAINS: bool
+  EXTRA_DOMAINS: str?
+  STAGING: bool
+  DISABLE_F2B: bool
+  SWAG_AUTORELOAD: bool
+  SWAG_AUTORELOAD_WATCHLIST: str?
+

--- a/swag/updater.json
+++ b/swag/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "swag",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-swag",
+  "upstream_version": "0.0.0"
+}

--- a/syncthing/CHANGELOG.md
+++ b/syncthing/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/syncthing/Dockerfile
+++ b/syncthing/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-syncthing/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-syncthing/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-syncthing/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-syncthing/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-syncthing/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8384" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/syncthing/build.json
+++ b/syncthing/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/syncthing:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/syncthing:amd64-latest"
+  }
+}

--- a/syncthing/config.yaml
+++ b/syncthing/config.yaml
@@ -1,0 +1,68 @@
+arch:
+  - aarch64
+  - amd64
+backup_exclude:
+  - "**/cache/"
+  - "**/log/"
+description:
+  Open source continuous file synchronization. Syncs files between devices
+  without a central server, using peer-to-peer TLS-encrypted connections.
+devices:
+  - /dev/fuse
+environment:
+  PGID: "0"
+  PUID: "0"
+homeassistant: 2024.1.0
+image: ghcr.io/rezusnet/syncthing-{arch}
+ingress: true
+ingress_port: 8384
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - media:rw
+  - share:rw
+  - ssl
+  - homeassistant_config:rw
+  - backup:rw
+name: Syncthing
+options:
+  env_vars: []
+  PGID: 0
+  PUID: 0
+  data_location: /share/syncthing
+  TZ: ""
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+panel_icon: mdi:sync
+ports:
+  8384/tcp: 8384
+  22000/tcp: 22000
+  22000/udp: 22000
+  21027/udp: 21027
+ports_description:
+  8384/tcp: WebUI (HTTP)
+  22000/tcp: Sync listening port (TCP)
+  22000/udp: Sync listening port (UDP)
+  21027/udp: Local discovery port (UDP)
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: str?
+  cifsdomain: str?
+slug: syncthing
+udev: true
+url: https://syncthing.net
+version: "1.0.0"
+

--- a/syncthing/updater.json
+++ b/syncthing/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "syncthing",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-syncthing",
+  "upstream_version": "0.0.0"
+}

--- a/syslog-ng/CHANGELOG.md
+++ b/syslog-ng/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/syslog-ng/Dockerfile
+++ b/syslog-ng/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-syslog-ng/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-syslog-ng/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-syslog-ng/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-syslog-ng/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-syslog-ng/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="6601" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/syslog-ng/build.json
+++ b/syslog-ng/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/syslog-ng:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/syslog-ng:amd64-latest"
+  }
+}

--- a/syslog-ng/config.yaml
+++ b/syslog-ng/config.yaml
@@ -1,0 +1,32 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "syslog-ng"
+description: "Centralized syslog server for log aggregation and routing"
+url: "https://github.com/linuxserver/docker-syslog-ng"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/syslog-ng-{arch}
+ports:
+  514/udp: 5514
+  601/tcp: 6601
+  6514/tcp: 6514
+ports_description:
+  514/udp: "Syslog UDP input"
+  601/tcp: "Syslog TCP input"
+  6514/tcp: "Syslog TLS input"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  LOG_TO_STDOUT: false
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  LOG_TO_STDOUT: bool?
+
+slug: syslog-ng
+version: "1.0.0"

--- a/syslog-ng/updater.json
+++ b/syslog-ng/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "syslog-ng",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-syslog-ng",
+  "upstream_version": "0.0.0"
+}

--- a/tautulli/CHANGELOG.md
+++ b/tautulli/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-tautulli/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-tautulli/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-tautulli/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-tautulli/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-tautulli/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/tautulli/build.json
+++ b/tautulli/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/tautulli:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/tautulli:amd64-latest"
+  }
+}

--- a/tautulli/config.yaml
+++ b/tautulli/config.yaml
@@ -1,0 +1,15 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  PGID: int
+  PUID: int
+  data_location: str
+  TZ: str?
+  DOCKER_MODS:
+    - match(^linuxserver/mods:tautulli-[a-z0-9-]+$)?
+
+slug: tautulli
+version: "1.0.0"

--- a/tautulli/updater.json
+++ b/tautulli/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "tautulli",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-tautulli",
+  "upstream_version": "0.0.0"
+}

--- a/telegram/CHANGELOG.md
+++ b/telegram/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/telegram/Dockerfile
+++ b/telegram/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-telegram/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-telegram/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-telegram/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-telegram/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-telegram/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/telegram/build.json
+++ b/telegram/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/telegram:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/telegram:amd64-latest"
+  }
+}

--- a/telegram/config.yaml
+++ b/telegram/config.yaml
@@ -1,0 +1,32 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Telegram"
+description: "Telegram messaging desktop app accessible via web browser (Selkies/KasmVNC)"
+url: "https://github.com/linuxserver/docker-telegram"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/telegram-{arch}
+ports:
+  3000/tcp: 3000
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: "Telegram desktop GUI (HTTP, must be proxied)"
+  3001/tcp: "Telegram desktop GUI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CUSTOM_USER: ""
+  PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CUSTOM_USER: str?
+  PASSWORD: str?
+
+slug: telegram
+version: "1.0.0"

--- a/telegram/updater.json
+++ b/telegram/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "telegram",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-telegram",
+  "upstream_version": "0.0.0"
+}

--- a/the-lounge/CHANGELOG.md
+++ b/the-lounge/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/the-lounge/Dockerfile
+++ b/the-lounge/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-thelounge/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-thelounge/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-thelounge/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-thelounge/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-thelounge/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="9000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/the-lounge/build.json
+++ b/the-lounge/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/thelounge:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/thelounge:amd64-latest"
+  }
+}

--- a/the-lounge/config.yaml
+++ b/the-lounge/config.yaml
@@ -1,0 +1,29 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "The Lounge"
+description: "Self-hosted web IRC client that stays connected when your browser is closed"
+url: "https://github.com/linuxserver/docker-thelounge"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/the-lounge-{arch}
+ingress: true
+ingress_port: 9000
+ingress_stream: true
+ports:
+  9000/tcp: 9000
+ports_description:
+  9000/tcp: "The Lounge WebUI"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: the-lounge
+version: "1.0.0"

--- a/the-lounge/updater.json
+++ b/the-lounge/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "the-lounge",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-thelounge",
+  "upstream_version": "0.0.0"
+}

--- a/tvheadend/CHANGELOG.md
+++ b/tvheadend/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/tvheadend/Dockerfile
+++ b/tvheadend/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-tvheadend/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-tvheadend/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-tvheadend/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-tvheadend/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-tvheadend/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="9981" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/tvheadend/build.json
+++ b/tvheadend/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/tvheadend:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/tvheadend:amd64-latest"
+  }
+}

--- a/tvheadend/config.yaml
+++ b/tvheadend/config.yaml
@@ -1,0 +1,35 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "TVHeadend"
+description: "TV streaming server and recorder (PVR) supporting DVB, IPTV, SAT>IP, and HDHomeRun"
+url: "https://github.com/linuxserver/docker-tvheadend"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/tvheadend-{arch}
+ingress: true
+ingress_port: 9981
+ports:
+  9981/tcp: 9981
+  9982/tcp: 9982
+ports_description:
+  9981/tcp: "TVHeadend WebUI"
+  9982/tcp: "HTSP server port (for Kodi/Movian clients)"
+map:
+  - config:rw
+devices:
+  - /dev/dri
+  - /dev/dvb
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  RUN_OPTS: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  RUN_OPTS: str?
+
+slug: tvheadend
+version: "1.0.0"

--- a/tvheadend/updater.json
+++ b/tvheadend/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "tvheadend",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-tvheadend",
+  "upstream_version": "0.0.0"
+}

--- a/ubooquity/CHANGELOG.md
+++ b/ubooquity/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/ubooquity/Dockerfile
+++ b/ubooquity/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-ubooquity/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-ubooquity/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-ubooquity/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-ubooquity/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-ubooquity/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="2203" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/ubooquity/build.json
+++ b/ubooquity/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/ubooquity:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/ubooquity:amd64-latest"
+  }
+}

--- a/ubooquity/config.yaml
+++ b/ubooquity/config.yaml
@@ -1,0 +1,35 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Ubooquity"
+description: "Lightweight comic and ebook server with OPDS support"
+url: "https://github.com/linuxserver/docker-ubooquity"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/ubooquity-{arch}
+ingress: true
+ingress_port: 2203
+ingress_path: "/ubooquity/admin"
+ports:
+  2202/tcp: 2202
+  2203/tcp: 2203
+ports_description:
+  2202/tcp: "Library web interface"
+  2203/tcp: "Admin panel"
+map:
+  - config:rw
+  - media:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  MAXMEM: 512
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  MAXMEM: int?
+
+slug: ubooquity
+version: "1.0.0"

--- a/ubooquity/updater.json
+++ b/ubooquity/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "ubooquity",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-ubooquity",
+  "upstream_version": "0.0.0"
+}

--- a/unifi-network-application/CHANGELOG.md
+++ b/unifi-network-application/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/unifi-network-application/Dockerfile
+++ b/unifi-network-application/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-unifi-network-application/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-unifi-network-application/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-unifi-network-application/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-unifi-network-application/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-unifi-network-application/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8443" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/unifi-network-application/build.json
+++ b/unifi-network-application/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/unifi-network-application:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/unifi-network-application:amd64-latest"
+  }
+}

--- a/unifi-network-application/config.yaml
+++ b/unifi-network-application/config.yaml
@@ -1,0 +1,64 @@
+arch:
+  - aarch64
+  - amd64
+description: >
+  Ubiquiti UniFi Network Application. Manages UniFi networking equipment
+  (access points, switches, gateways). Requires an external MongoDB database.
+homeassistant: 2024.1.0
+host_network: true
+icon: icon.png
+image: ghcr.io/rezusnet/unifi-network-application-{arch}
+ingress: true
+ingress_port: 8443
+ingress_ssl: true
+ingress_stream: true
+init: false
+map:
+  - addon_config:rw
+  - share:rw
+name: UniFi Network Application
+options:
+  PUID: 0
+  PGID: 0
+  TZ: ""
+  MONGO_USER: unifi
+  MONGO_PASS: ""
+  MONGO_HOST: ""
+  MONGO_PORT: 27017
+  MONGO_DBNAME: unifi
+  MONGO_AUTHSOURCE: admin
+  MEM_LIMIT: 1024
+  MEM_STARTUP: 1024
+  env_vars: []
+  localdisks: ""
+  networkdisks: ""
+  cifsusername: ""
+  cifspassword: ""
+  cifsdomain: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str?
+  MONGO_USER: str
+  MONGO_PASS: password
+  MONGO_HOST: str
+  MONGO_PORT: int
+  MONGO_DBNAME: str
+  MONGO_AUTHSOURCE: str
+  MEM_LIMIT: int?
+  MEM_STARTUP: int?
+  MONGO_TLS: bool?
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  localdisks: str?
+  networkdisks: str?
+  cifsusername: str?
+  cifspassword: password?
+  cifsdomain: str?
+slug: unifi-network-application
+startup: application
+boot: auto
+url: https://github.com/rezusnet/hassio-addons
+version: "1.0.0"
+

--- a/unifi-network-application/updater.json
+++ b/unifi-network-application/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "unifi-network-application",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-unifi-network-application",
+  "upstream_version": "0.0.0"
+}

--- a/webgrab+plus/CHANGELOG.md
+++ b/webgrab+plus/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/webgrab+plus/Dockerfile
+++ b/webgrab+plus/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-webgrabplus/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-webgrabplus/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-webgrabplus/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-webgrabplus/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-webgrabplus/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/webgrab+plus/build.json
+++ b/webgrab+plus/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/webgrabplus:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/webgrabplus:amd64-latest"
+  }
+}

--- a/webgrab+plus/config.yaml
+++ b/webgrab+plus/config.yaml
@@ -1,0 +1,25 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "WebGrab+Plus"
+description: "Multi-site incremental XMLTV EPG grabber for TV guides"
+url: "https://github.com/linuxserver/docker-webgrabplus"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/webgrab+plus-{arch}
+ports: {}
+ports_description: {}
+map:
+  - config:rw
+  - share:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: webgrab+plus
+version: "1.0.0"

--- a/webgrab+plus/updater.json
+++ b/webgrab+plus/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "webgrab+plus",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-webgrabplus",
+  "upstream_version": "0.0.0"
+}

--- a/wikijs/CHANGELOG.md
+++ b/wikijs/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/wikijs/Dockerfile
+++ b/wikijs/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-wikijs/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-wikijs/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-wikijs/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-wikijs/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-wikijs/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/wikijs/build.json
+++ b/wikijs/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/wikijs:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/wikijs:amd64-latest"
+  }
+}

--- a/wikijs/config.yaml
+++ b/wikijs/config.yaml
@@ -1,0 +1,29 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Wiki.js"
+description: "Modern, powerful wiki app built on Node.js with Git support"
+version: "1.0.0"
+slug: "wikijs"
+url: "https://github.com/rezusnet/hassio-addons/tree/master/wikijs"
+arch:
+  - amd64
+  - arm64
+startup: "application"
+boot: "auto"
+map:
+  - config:rw
+  - ssl
+ports:
+  3000/tcp: 3000
+options:
+  db_type: "sqlite"
+  tz: "Etc/UTC"
+schema:
+  db_type: "list(sqlite|postgres)"
+  db_host: "str?"
+  db_port: "int?"
+  db_name: "str?"
+  db_user: "str?"
+  db_pass: "password?"
+  tz: "str"
+

--- a/wikijs/updater.json
+++ b/wikijs/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "wikijs",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-wikijs",
+  "upstream_version": "0.0.0"
+}

--- a/wireguard/CHANGELOG.md
+++ b/wireguard/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-wireguard/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-wireguard/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-wireguard/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-wireguard/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-wireguard/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/wireguard/build.json
+++ b/wireguard/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/wireguard:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/wireguard:amd64-latest"
+  }
+}

--- a/wireguard/config.yaml
+++ b/wireguard/config.yaml
@@ -1,0 +1,30 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: WireGuard
+description: Fast, modern VPN server using the WireGuard protocol
+slug: wireguard
+url: https://github.com/linuxserver/docker-wireguard
+arch:
+  - amd64
+  - aarch64
+image: ghcr.io/rezusnet/wireguard-{arch}
+version: "1.0.0"
+map:
+  - addon_config:rw
+ports:
+  51820/udp: 51820
+ports_description:
+  51820/udp: WireGuard VPN port
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  SERVERURL: "auto"
+  SERVERPORT: 51820
+  PEERS: 1
+  PEERDNS: "auto"
+  INTERNAL_SUBNET: "10.13.13.0"
+  ALLOWEDIPS: "0.0.0.0/0"
+  PERSISTENTKEEPALIVE_PEERS: ""
+  LOG_CONFS: true
+

--- a/wireguard/updater.json
+++ b/wireguard/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "wireguard",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-wireguard",
+  "upstream_version": "0.0.0"
+}

--- a/wireshark/CHANGELOG.md
+++ b/wireshark/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-wireshark/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-wireshark/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-wireshark/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-wireshark/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-wireshark/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/wireshark/build.json
+++ b/wireshark/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/wireshark:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/wireshark:amd64-latest"
+  }
+}

--- a/wireshark/config.yaml
+++ b/wireshark/config.yaml
@@ -1,0 +1,32 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Wireshark"
+description: "Network protocol analyzer via web-based desktop interface (Selkies)"
+url: "https://github.com/linuxserver/docker-wireshark"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/wireshark-{arch}
+ports:
+  3000/tcp: 3000
+  3001/tcp: 3001
+ports_description:
+  3000/tcp: "Wireshark desktop GUI (HTTP, proxied only)"
+  3001/tcp: "Wireshark desktop GUI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  CUSTOM_USER: ""
+  PASSWORD: ""
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  CUSTOM_USER: str?
+  PASSWORD: password?
+
+slug: wireshark
+version: "1.0.0"

--- a/wireshark/updater.json
+++ b/wireshark/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "wireshark",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-baseimage-selkies",
+  "upstream_version": "0.0.0"
+}

--- a/xbackbone/CHANGELOG.md
+++ b/xbackbone/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/xbackbone/Dockerfile
+++ b/xbackbone/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-xbackbone/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-xbackbone/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-xbackbone/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-xbackbone/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-xbackbone/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/xbackbone/build.json
+++ b/xbackbone/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/xbackbone:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/xbackbone:amd64-latest"
+  }
+}

--- a/xbackbone/config.yaml
+++ b/xbackbone/config.yaml
@@ -1,0 +1,28 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "XBackBone"
+description: "Lightweight self-hosted file host with PHP — drag-and-drop upload, multi-user management, ShareX support"
+url: "https://github.com/linuxserver/docker-xbackbone"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/xbackbone-{arch}
+ports:
+  80/tcp: 8080
+  443/tcp: 8443
+ports_description:
+  80/tcp: "XBackBone web UI (HTTP)"
+  443/tcp: "XBackBone web UI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+
+slug: xbackbone
+version: "1.0.0"

--- a/xbackbone/updater.json
+++ b/xbackbone/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "xbackbone",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-xbackbone",
+  "upstream_version": "0.0.0"
+}

--- a/your-spotify/CHANGELOG.md
+++ b/your-spotify/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/your-spotify/Dockerfile
+++ b/your-spotify/Dockerfile
@@ -1,0 +1,80 @@
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-your_spotify/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-your_spotify/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-your_spotify/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-your_spotify/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-your_spotify/run
+
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+ARG CACHEBUST=1
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+ENV PACKAGES="nginx"
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=60s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/your-spotify/build.json
+++ b/your-spotify/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "lscr.io/linuxserver/your_spotify:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/your_spotify:amd64-latest"
+  }
+}

--- a/your-spotify/config.yaml
+++ b/your-spotify/config.yaml
@@ -1,0 +1,38 @@
+icon: icon.png
+homeassistant: "2024.1.0"
+name: "Your Spotify"
+description: "Self-hosted Spotify listening history dashboard with statistics"
+url: "https://github.com/linuxserver/docker-your_spotify"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/rezusnet/your-spotify-{arch}
+ports:
+  80/tcp: 8080
+  443/tcp: 8443
+ports_description:
+  80/tcp: "Your Spotify web UI (HTTP)"
+  443/tcp: "Your Spotify web UI (HTTPS)"
+map:
+  - config:rw
+options:
+  PUID: 1000
+  PGID: 1000
+  TZ: "Etc/UTC"
+  APP_URL: "http://localhost"
+  SPOTIFY_PUBLIC: ""
+  SPOTIFY_SECRET: ""
+  CORS: "http://localhost:80,https://localhost:443"
+  MONGO_ENDPOINT: "mongodb://mongo:27017/your_spotify"
+schema:
+  PUID: int
+  PGID: int
+  TZ: str
+  APP_URL: str
+  SPOTIFY_PUBLIC: str
+  SPOTIFY_SECRET: password
+  CORS: str
+  MONGO_ENDPOINT: str
+
+slug: your-spotify
+version: "1.0.0"

--- a/your-spotify/updater.json
+++ b/your-spotify/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-04-27",
+  "paused": false,
+  "repository": "rezusnet/hassio-addons",
+  "slug": "your-spotify",
+  "source": "github",
+  "upstream_repo": "linuxserver/docker-your_spotify",
+  "upstream_version": "0.0.0"
+}


### PR DESCRIPTION
## Summary

- Implements 95 LSIO-based HA add-ons from all open issues (#18–#119)
- Each add-on follows the standard LSIO template pattern with `ha_lsio.sh`, S6 init patching, HA modules, nginx for ingress, and bashio-standalone
- All add-ons include `config.yaml`, `Dockerfile`, `build.json`, `updater.json`, and `CHANGELOG.md`
- Marked `[nobuild]` to skip initial CI builds until reviewed

## Add-ons Included

<details><summary>Full list (95 add-ons)</summary>

airsonic-advanced, babybuddy, beets, bookstack, calibre-web, changedetection, code-server, cops, darktable, davos, ddclient, deluge, diskover, dokuwiki, doplarr, duckdns, duplicati, emby-media-server, fail2ban, ferdium, flexget, grav, grocy, habridge, healthchecks, heimdall, hishtory-server, home-assistant (lsio), htpc-manager, kavita, kimai, kometa, ldap-auth, librespeed, lidarr, lychee, mastodon, medusa, minisatip, monica, mstream, manyfold, mariadb, mylar3, netbox, nextcloud, ngircd, nginx, nzbhydra2, obsidian, ombi, openssh-server, oscam, overseerr, pairdrop, phpmyadmin, piwigo, planka, plex, pwndrop, pydio-cells, pyload-ng, raneto, readarr, resilio-sync, rsnapshot, sealskin, sickgear, smokeping, speedtest-tracker, spotube, syncthing, syslog-ng, tautulli, telegram, the-lounge, tvheadend, ubooquity, unifi-network-application, webgrab+plus, wikijs, wireshark, wireguard, xbackbone, your-spotify, swag, freshrss, hedgedoc, piper, faster-whisper, adguardhome-sync, projectsend, openvscode-server

</details>

## Testing

- Each add-on was generated from its issue spec (config.yaml, build.json, ports, ingress settings)
- Ingress ports derived from healthcheck ports (not left at 0)
- Slugs validated against directory names
- `[nobuild]` prefix avoids triggering 95 parallel CI builds