### PR TITLE
fix: reorder sed substitution before inserts in media stack Dockerfiles

### DIFF
--- a/bazarr/Dockerfile
+++ b/bazarr/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-bazarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-bazarr/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-bazarr/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-bazarr/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-bazarr/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-bazarr/run
 
 COPY rootfs/ /

--- a/prowlarr/Dockerfile
+++ b/prowlarr/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-prowlarr/run
 
 COPY rootfs/ /

--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
 
 COPY rootfs/ /

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-radarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-radarr/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-radarr/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-radarr/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-radarr/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-radarr/run
 
 COPY rootfs/ /

--- a/sonarr/Dockerfile
+++ b/sonarr/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-sonarr/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-sonarr/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-sonarr/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-sonarr/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-sonarr/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-sonarr/run
 
 COPY rootfs/ /

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -17,9 +17,9 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 
 RUN \
     sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-transmission/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-transmission/run && \
     sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-transmission/run && \
     sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-transmission/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-transmission/run && \
     sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-transmission/run
 
 COPY rootfs/ /


### PR DESCRIPTION
## Summary
- Reorder sed commands in all 6 media stack Dockerfiles (sonarr, radarr, prowlarr, bazarr, qbittorrent, transmission) to run `s|/config|$LOCATION|g` BEFORE the `1a` line inserts
- Without this fix, the substitution runs after the fallback `LOCATION=/config` is inserted, turning it into `LOCATION=$LOCATION` (self-referencing, broken `data_location` option)
- Same fix pattern as jellyfin PR #121

## Why
The `sed -i "1a"` inserts add lines after line 1 (shebang). If the `s|/config|$LOCATION|g` substitution runs AFTER those inserts, it also replaces the literal `/config` in the fallback line, making the fallback use `$LOCATION` instead of `/config`.

## Affected add-ons
- sonarr
- radarr
- prowlarr
- bazarr
- qbittorrent
- transmission