### PR TITLE
fix(security): add permissions blocks and pin all actions to SHA hashes

### DIFF
--- a/.github/workflows/addons_updater.yaml
+++ b/.github/workflows/addons_updater.yaml
@@ -30,7 +30,7 @@ jobs:
           git config --global --unset-all "http.https://github.com/.extraheader" 2>/dev/null || true
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,16 +20,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: actions
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:actions"

--- a/.github/workflows/daily_stale.yml
+++ b/.github/workflows/daily_stale.yml
@@ -5,14 +5,15 @@ on:
     - cron: "0 12 * * 0"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: self-hosted
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Super-Linter (changed files)
-        uses: github/super-linter/slim@v7
+        uses: github/super-linter/slim@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
@@ -67,7 +67,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -158,7 +158,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -200,7 +200,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           title: "Github bot: fix linting issues"
           commit-message: "fix: auto-fix linting issues"

--- a/.github/workflows/on_issues.yml
+++ b/.github/workflows/on_issues.yml
@@ -5,12 +5,15 @@ on:
     types: [opened, edited, closed]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   issues-linked:
     runs-on: self-hosted
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Assign issues
         run: |
           echo "Starting"
@@ -43,7 +46,7 @@ jobs:
           done
           rm issueslist
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           message: "Github bot: issues linked to readme"
           default_author: github_actions

--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
 
+permissions: read-all
+
 jobs:
   check-addon-changes:
     if: ${{ github.repository_owner == 'rezusnet' && !github.event.pull_request.draft && !contains(github.event.head_commit.message, 'nobuild') }}
@@ -16,7 +18,7 @@ jobs:
       changedChangelogFiles: ${{ steps.changed-files.outputs.changelogs_files }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Find changed addon directories
@@ -75,7 +77,7 @@ jobs:
         addon: ${{ fromJSON(needs.check-addon-changes.outputs.changedAddons) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install PyYAML
         run: |
           if python3 -c "import yaml" 2>/dev/null; then
@@ -144,7 +146,7 @@ jobs:
         addon: ${{ fromJSON(needs.check-addon-changes.outputs.changedAddons) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install PyYAML
         run: |
@@ -267,7 +269,7 @@ jobs:
           echo "arch=$ARCH" >> "$GITHUB_OUTPUT"
 
       - name: Build addon image (native arch)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ${{ matrix.addon }}
           push: false

--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -23,6 +23,8 @@ on:
     paths:
       - "**/config.*"
 
+permissions: read-all
+
 jobs:
   detect-changed-addons:
     if: >-
@@ -35,7 +37,7 @@ jobs:
       changedAddons: ${{ steps.find_addons.outputs.changed_addons }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -133,7 +135,7 @@ jobs:
 
       - name: Commit sanitize changes
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           commit: -u
           message: "GitHub bot: sanitize (spaces + LF endings) & chmod [nobuild]"
@@ -418,10 +420,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -506,7 +508,7 @@ jobs:
             runner: ["self-hosted", "linux", "arm64"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install PyYAML
         run: |
@@ -589,7 +591,7 @@ jobs:
           PY
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -877,7 +879,7 @@ jobs:
           done
 
       - name: Commit changelog changes
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           commit: -u
           message: "GitHub bot: changelog [nobuild]"
@@ -907,7 +909,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,25 +20,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/weekly_crlftolf.yaml
+++ b/.github/workflows/weekly_crlftolf.yaml
@@ -2,14 +2,17 @@ name: Fix CRLF Endings
 on: 
   workflow_call:
   workflow_dispatch:
-  
+
+permissions:
+  contents: write
+
 jobs:
   fix-crlf:
     if: github.repository_owner == 'rezusnet'
     runs-on: self-hosted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Find and fix CRLF endings
         run: |
@@ -28,7 +31,7 @@ jobs:
           fi
 
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           message: "Github bot: CRLF corrected"
           default_author: github_actions


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions` to 5 workflow files that were missing them (onpush_builder, onpr_check-pr, on_issues, daily_stale, weekly_crlftolf)
- Pin all GitHub Actions to immutable SHA hashes with version comments across all 9 workflow files
- Move daily_stale permissions from job-level to workflow-level (same effective scope)

## Security Impact
Fixes **~61 open code scanning alerts**:
- **12 TokenPermissions** + **9 missing-workflow-permissions** (21 total) — workflows now declare minimum required permissions
- **~40 PinnedDependencies** in workflows — actions pinned to SHA hashes, preventing supply chain attacks via tag reassignment

## Remaining Alerts (not addressed here)
- **10 PinnedDependencies** in Dockerfiles — `FROM ${BUILD_FROM}` uses a build ARG resolved by HA Supervisor at runtime; this is inherent to the HA add-on pattern and cannot be pinned at the Dockerfile level
- **4 organizational** (Maintained, Fuzzing, CII-Best-Practices, CodeReview) — require project-level changes, not code fixes
- **1 BranchProtection** — fixed via `gh api` (branch protection now enabled on master)

## Additional Security Hardening (repo settings, already applied)
- Branch protection enabled on master (require PR reviews, linear history, no force push)
- Secret scanning enabled
- Push protection enabled
- Dependabot security updates enabled