### PR TITLE
fix(ci): use version tags instead of pinned SHAs

### DIFF
--- a/.github/workflows/addons_updater.yaml
+++ b/.github/workflows/addons_updater.yaml
@@ -30,7 +30,7 @@ jobs:
           git config --global --unset-all "http.https://github.com/.extraheader" 2>/dev/null || true
 
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447e83dd # v6
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
             (inputs.dry_run || 'false') != 'true'
           }}
         id: cpr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9522fcc4c85730 # v7
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update upstream versions $(date +%Y-%m-%d)"


### PR DESCRIPTION
The pinned SHAs for actions/checkout and peter-evans/create-pull-request failed to resolve on the self-hosted runner. Use version tags instead.