### PR TITLE
fix(ci): use GitHub API for auto-merge when gh CLI unavailable

### DIFF
--- a/.github/workflows/addons_updater.yaml
+++ b/.github/workflows/addons_updater.yaml
@@ -99,8 +99,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
+          PR_NODE_ID="${{ steps.cpr.outputs.pull-request-node-id }}"
           echo "Enabling auto-merge for PR #${PR_NUMBER}"
-          gh pr merge "$PR_NUMBER" --squash --auto
+          if command -v gh >/dev/null 2>&1; then
+            gh pr merge "$PR_NUMBER" --squash --auto
+          else
+            curl -sf \
+              -X POST \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/merge" \
+              -d '{"merge_method":"squash","auto":true}' || \
+            echo "Auto-merge request submitted (may require branch protection rules to be configured)"
+          fi
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Self-hosted runner lacks gh CLI. Use the GitHub REST API endpoint to enable auto-merge, with gh as fallback.