### PR TITLE
fix: PairDrop EADDRINUSE crash loop (v1.11.2-1)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-1 (2026-05-03)
+
+- Fix EADDRINUSE crash loop by providing custom svc-pairdrop/run script
+- Properly handle S6 service lifecycle with cd before exec
+
 ## 1.11.2 (2026-05-03)
 
 - Initial release based on PairDrop 1.11.2

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -16,16 +16,14 @@ ARG CONFIGLOCATION="/config"
 RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
 
 RUN \
-    for svc in init-pairdrop-config svc-pairdrop; do \
-        runfile="/etc/s6-overlay/s6-rc.d/${svc}/run"; \
-        if [ -f "$runfile" ]; then \
-            sed -i "s|contenv bash|contenv bashio|g" "$runfile" && \
-            sed -i "s|/config|\$LOCATION|g" "$runfile" && \
-            sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" "$runfile" && \
-            sed -i "1a LOCATION=\$(bashio::config 'data_location')" "$runfile" && \
-            sed -i "1a set +u" "$runfile"; \
-        fi; \
-    done
+    runfile="/etc/s6-overlay/s6-rc.d/init-pairdrop-config/run"; \
+    if [ -f "$runfile" ]; then \
+        sed -i "s|contenv bash|contenv bashio|g" "$runfile" && \
+        sed -i "s|/config|\$LOCATION|g" "$runfile" && \
+        sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" "$runfile" && \
+        sed -i "1a LOCATION=\$(bashio::config 'data_location')" "$runfile" && \
+        sed -i "1a set +u" "$runfile"; \
+    fi
 
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -80,4 +80,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2"
+version: "1.11.2-1"

--- a/pairdrop/rootfs/etc/cont-init.d/99-run.sh
+++ b/pairdrop/rootfs/etc/cont-init.d/99-run.sh
@@ -10,33 +10,6 @@ if [[ "${LOCATION}" = "null" || -z "${LOCATION}" ]]; then
     LOCATION=/config
 fi
 
-if bashio::config.has_value 'TZ'; then
-    TZ_VAL="$(bashio::config 'TZ')"
-    export TZ="${TZ_VAL}"
-    bashio::log.info "Timezone set to ${TZ}"
-fi
-
 mkdir -p "${LOCATION}"
-
-if bashio::config.true 'rate_limit'; then
-    export RATE_LIMIT="true"
-    bashio::log.info "Rate limiting enabled"
-else
-    export RATE_LIMIT="false"
-fi
-
-if bashio::config.true 'ws_fallback'; then
-    export WS_FALLBACK="true"
-    bashio::log.info "WebSocket fallback enabled"
-else
-    export WS_FALLBACK="false"
-fi
-
-if bashio::config.true 'debug_mode'; then
-    export DEBUG_MODE="true"
-    bashio::log.warning "Debug mode enabled - client IPs will be logged"
-else
-    export DEBUG_MODE="false"
-fi
 
 bashio::log.info "PairDrop initialization complete"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -1,0 +1,48 @@
+#!/usr/bin/env bashio
+# shellcheck shell=bash
+set +u
+
+LOCATION="$(bashio::config 'data_location')"
+if [[ "${LOCATION}" = "null" || -z "${LOCATION}" ]]; then
+    LOCATION=/config
+fi
+
+export HOME="${LOCATION}"
+
+if bashio::config.has_value 'TZ'; then
+    export TZ="$(bashio::config 'TZ')"
+fi
+
+if bashio::config.true 'rate_limit'; then
+    export RATE_LIMIT="true"
+else
+    export RATE_LIMIT="false"
+fi
+
+if bashio::config.true 'ws_fallback'; then
+    export WS_FALLBACK="true"
+else
+    export WS_FALLBACK="false"
+fi
+
+if bashio::config.true 'debug_mode'; then
+    export DEBUG_MODE="true"
+else
+    export DEBUG_MODE="false"
+fi
+
+OPT_RATE_LIMIT=""
+OPT_WS_FALLBACK=""
+
+if [[ "${RATE_LIMIT}" = "true" ]]; then
+    OPT_RATE_LIMIT="--rate-limit"
+fi
+
+if [[ "${WS_FALLBACK}" = "true" ]]; then
+    OPT_WS_FALLBACK="--include-ws-fallback"
+fi
+
+cd /app/pairdrop || exit 1
+
+exec s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
+    s6-setuidgid abc npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"


### PR DESCRIPTION
## Summary

- Fix EADDRINUSE crash loop by providing custom `svc-pairdrop/run` script
- The LSIO `svc-pairdrop/run` uses `cd /app/pairdrop` as an exec target (not a binary), causing S6 to restart the service while the orphaned npm process still holds port 3000
- Custom run script does `cd` before `exec` into `s6-notifyoncheck`
- Bump version to `1.11.2-1` to force Supervisor image repull

Follow-up to #281