### PR TITLE
fix: PairDrop crash loop - exec node directly (v1.11.2-2)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-2 (2026-05-03)
+
+- Fix crash loop: exec directly into node instead of npm (npm forks and exits, confusing S6)
+
 ## 1.11.2-1 (2026-05-03)
 
 - Fix EADDRINUSE crash loop by providing custom svc-pairdrop/run script

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -80,4 +80,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-1"
+version: "1.11.2-2"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -8,6 +8,7 @@ if [[ "${LOCATION}" = "null" || -z "${LOCATION}" ]]; then
 fi
 
 export HOME="${LOCATION}"
+export NODE_ENV="production"
 
 if bashio::config.has_value 'TZ'; then
     export TZ="$(bashio::config 'TZ')"
@@ -31,18 +32,7 @@ else
     export DEBUG_MODE="false"
 fi
 
-OPT_RATE_LIMIT=""
-OPT_WS_FALLBACK=""
-
-if [[ "${RATE_LIMIT}" = "true" ]]; then
-    OPT_RATE_LIMIT="--rate-limit"
-fi
-
-if [[ "${WS_FALLBACK}" = "true" ]]; then
-    OPT_WS_FALLBACK="--include-ws-fallback"
-fi
-
 cd /app/pairdrop || exit 1
 
 exec s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
-    s6-setuidgid abc npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
+    s6-setuidgid abc node server/index.js


### PR DESCRIPTION
Fix EADDRINUSE crash loop by exec-ing into node directly instead of npm start (which forks and exits, causing S6 to restart).