### PR TITLE
fix: PairDrop - remove S6 at build time (v1.11.2-4)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-4 (2026-05-03)
+
+- Remove S6 overlay at build time (Dockerfile), not runtime
+- Run PairDrop directly via tini (no S6 service management)
+
 ## 1.11.2-3 (2026-05-03)
 
 - Switch to non-LSIO pattern: remove S6 overlay, run node directly via tini

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -7,9 +7,7 @@ ARG BUILD_VERSION
 
 USER root
 
-ENV S6_CMD_WAIT_FOR_SERVICES=1 \
-    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_SERVICES_GRACETIME=0
+RUN rm -rf /etc/services.d /etc/s6-overlay /etc/cont-init.d /etc/cont-finish.d /defaults
 
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -80,4 +80,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-3"
+version: "1.11.2-4"

--- a/pairdrop/rootfs/etc/cont-init.d/99-run.sh
+++ b/pairdrop/rootfs/etc/cont-init.d/99-run.sh
@@ -36,10 +36,6 @@ else
     export DEBUG_MODE="false"
 fi
 
-for folders in /etc/services.d /etc/s6-overlay; do
-    [[ -d "$folders" ]] && rm -r "$folders"
-done
-
 cd /app/pairdrop || bashio::exit.nok "Cannot find /app/pairdrop"
 
 bashio::log.info "Starting PairDrop on port 3000..."


### PR DESCRIPTION
Remove S6 overlay directories in Dockerfile at build time instead of runtime. Prevents LSIO S6 services from starting and conflicting.