### PR TITLE
fix: PairDrop - force image re-pull (v1.11.2-5)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-5 (2026-05-03)
+
+- Same as 1.11.2-4: remove S6 overlay at build time, run node directly via tini
+- New tag to force Supervisor image re-pull (Docker layer caching issue)
+
 ## 1.11.2-4 (2026-05-03)
 
 - Remove S6 overlay at build time (Dockerfile), not runtime

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -80,4 +80,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-4"
+version: "1.11.2-5"


### PR DESCRIPTION
New image tag to force Supervisor to pull fresh image with S6 overlay removed at build time.