### PR TITLE
fix: PairDrop - replace /init to disable S6 (v1.11.2-6)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-6 (2026-05-03)
+
+- Replace /init (S6 binary) with passthrough script to prevent S6 overlay extraction at runtime
+
 ## 1.11.2-5 (2026-05-03)
 
 - Same as 1.11.2-4: remove S6 overlay at build time, run node directly via tini

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -7,7 +7,8 @@ ARG BUILD_VERSION
 
 USER root
 
-RUN rm -rf /etc/services.d /etc/s6-overlay /etc/cont-init.d /etc/cont-finish.d /defaults
+RUN rm -rf /etc/services.d /etc/s6-overlay /etc/cont-init.d /etc/cont-finish.d /defaults && \
+    printf '#!/bin/sh\nexec "$@"\n' > /init && chmod +x /init
 
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -80,4 +80,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-5"
+version: "1.11.2-6"


### PR DESCRIPTION
Replace /init binary with passthrough script to prevent S6 overlay from extracting at runtime.