### PR TITLE
fix: PairDrop hadolint - COPY run script (v1.11.2-9)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-9 (2026-05-03)
+
+- Fix hadolint: use COPY for svc-pairdrop/run instead of heredoc
+
 ## 1.11.2-8 (2026-05-03)
 
 - Rewrite to pure LSIO pattern (init:false, S6 manages service lifecycle)

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -15,38 +15,7 @@ COPY ha_lsio.sh /ha_lsio.sh
 ARG CONFIGLOCATION="/config"
 RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
 
-RUN cat > /etc/s6-overlay/s6-rc.d/svc-pairdrop/run << 'RUNEOF'
-#!/usr/bin/with-contenv bashio
-# shellcheck shell=bash
-set +u
-
-LOCATION="$(bashio::config 'data_location')"
-if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi
-RATE_LIMIT="$(bashio::config 'rate_limit')"
-WS_FALLBACK="$(bashio::config 'ws_fallback')"
-DEBUG_MODE="$(bashio::config 'debug_mode')"
-export DEBUG_MODE
-
-mkdir -p "$LOCATION"
-
-if [[ ${RATE_LIMIT,,} = "true" ]]; then
-    OPT_RATE_LIMIT="--rate-limit"
-fi
-
-if [[ ${WS_FALLBACK,,} = "true" ]]; then
-    OPT_WS_FALLBACK="--include-ws-fallback"
-fi
-
-if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
-    HOME=$LOCATION exec \
-        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
-        cd /app/pairdrop s6-setuidgid abc npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
-else
-    HOME=$LOCATION exec \
-        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
-        cd /app/pairdrop npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
-fi
-RUNEOF
+COPY rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
 RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
 
 ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -1,3 +1,4 @@
+---
 arch:
   - aarch64
   - amd64
@@ -80,4 +81,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-8"
+version: "1.11.2-9"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -1,0 +1,30 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set +u
+
+LOCATION="$(bashio::config 'data_location')"
+if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi
+RATE_LIMIT="$(bashio::config 'rate_limit')"
+WS_FALLBACK="$(bashio::config 'ws_fallback')"
+DEBUG_MODE="$(bashio::config 'debug_mode')"
+export DEBUG_MODE
+
+mkdir -p "$LOCATION"
+
+if [[ ${RATE_LIMIT,,} = "true" ]]; then
+    OPT_RATE_LIMIT="--rate-limit"
+fi
+
+if [[ ${WS_FALLBACK,,} = "true" ]]; then
+    OPT_WS_FALLBACK="--include-ws-fallback"
+fi
+
+if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
+    HOME=$LOCATION exec \
+        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
+        cd /app/pairdrop s6-setuidgid abc npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
+else
+    HOME=$LOCATION exec \
+        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
+        cd /app/pairdrop npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
+fi


### PR DESCRIPTION
Fix hadolint parse error caused by heredoc in Dockerfile. Use COPY for svc-pairdrop/run instead. Also fix yamllint warnings (empty brackets, missing document start).