### PR TITLE
fix: PairDrop - node directly instead of npm start (v1.11.2-10)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-10 (2026-05-03)
+
+- Fix EADDRINUSE: replace `npm start` with `node server/index.js` directly
+  (npm spawns node as child; when S6 kills npm, orphaned node keeps port bound)
+
 ## 1.11.2-9 (2026-05-03)
 
 - Fix hadolint: use COPY for svc-pairdrop/run instead of heredoc

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -81,4 +81,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-9"
+version: "1.11.2-10"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+exec sleep 5

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -22,9 +22,9 @@ fi
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     HOME=$LOCATION exec \
         s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
-        cd /app/pairdrop s6-setuidgid abc npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
+        cd /app/pairdrop s6-setuidgid abc node server/index.js "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
 else
     HOME=$LOCATION exec \
         s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 3000" \
-        cd /app/pairdrop npm start -- "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
+        cd /app/pairdrop node server/index.js "${OPT_RATE_LIMIT}" "${OPT_WS_FALLBACK}"
 fi


### PR DESCRIPTION
Root cause: npm spawns node as child process. When S6 kills npm (run script exits), the orphaned node process keeps port 3000 bound. S6 restarts, new instance gets EADDRINUSE.

Fix: use `node server/index.js` directly instead of `npm start` so S6 tracks the actual node process.