### PR TITLE
fix: PairDrop - bash shebang + source bashio (v1.11.2-11)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-11 (2026-05-07)
+
+- Fix shebang: use `#!/usr/bin/with-contenv bash` + source bashio-standalone.sh
+  (`bashio` is not a valid interpreter, causing S6 run script to fail silently)
+
 ## 1.11.2-10 (2026-05-03)
 
 - Fix EADDRINUSE: replace `npm start` with `node server/index.js` directly

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -81,4 +81,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-10"
+version: "1.11.2-11"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -1,6 +1,8 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 set +u
+
+source /usr/local/lib/bashio-standalone.sh
 
 LOCATION="$(bashio::config 'data_location')"
 if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi


### PR DESCRIPTION
Fix shebang: `#!/usr/bin/with-contenv bashio` fails because bashio is not a valid interpreter. Use `#!/usr/bin/with-contenv bash` and source bashio-standalone.sh.