### PR TITLE
fix: PairDrop - prevent EADDRINUSE crash loop (v1.11.2-12)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.2-12 (2026-05-07)
+
+- Fix EADDRINUSE crash loop: add finish script that waits for port 3000 release
+- Add port availability pre-check in run script before starting node
+- Wait up to 30s for port to be freed on both start and finish
+
 ## 1.11.2-11 (2026-05-07)
 
 - Fix shebang: use `#!/usr/bin/with-contenv bash` + source bashio-standalone.sh

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -16,7 +16,8 @@ ARG CONFIGLOCATION="/config"
 RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
 
 COPY rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
-RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+COPY rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish /etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
+RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-pairdrop/run /etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
 
 ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
 

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -81,4 +81,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-11"
+version: "1.11.2-12"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
@@ -1,3 +1,8 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/with-contenv bash
 # shellcheck shell=bash
-exec sleep 5
+for _ in $(seq 1 30); do
+    if ! nc -z localhost 3000 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -13,6 +13,13 @@ export DEBUG_MODE
 
 mkdir -p "$LOCATION"
 
+for _ in $(seq 1 30); do
+    if ! nc -z localhost 3000 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
 if [[ ${RATE_LIMIT,,} = "true" ]]; then
     OPT_RATE_LIMIT="--rate-limit"
 fi


### PR DESCRIPTION
Fix EADDRINUSE crash loop by adding finish script (waits for port 3000 release) and port availability pre-check in run script.