### PR TITLE
fix: PairDrop - remove host_network, fix EADDRINUSE (v1.11.2-13)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.2-13 (2026-05-07)
+
+- Remove host_network to fix EADDRINUSE crash loop (conflict with Grafana on port 3000)
+- Switch to bridge networking with ingress-only access by default
+- Port 3000/tcp is now optional (null by default, ingress recommended)
+
 ## 1.11.2-12 (2026-05-07)
 
 - Fix EADDRINUSE crash loop: add finish script that waits for port 3000 release

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -27,7 +27,6 @@ devices:
 environment:
   ATTACHED_DEVICES_PERMS: "/dev/dri -type c -o -type f"
 homeassistant: 2024.1.0
-host_network: true
 icon: icon.png
 image: ghcr.io/rezusnet/pairdrop-{arch}
 ingress: true
@@ -56,12 +55,9 @@ options:
   debug_mode: false
 panel_icon: mdi:share-variant
 ports:
-  3000/tcp: 3000
+  3000/tcp: null
 ports_description:
-  3000/tcp: Web UI for file sharing
-privileged:
-  - SYS_ADMIN
-  - DAC_READ_SEARCH
+  3000/tcp: Web UI for file sharing (optional, ingress recommended)
 schema:
   env_vars:
     - name: match(^[A-Za-z0-9_]+$)
@@ -81,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-12"
+version: "1.11.2-13"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/run
@@ -13,13 +13,6 @@ export DEBUG_MODE
 
 mkdir -p "$LOCATION"
 
-for _ in $(seq 1 30); do
-    if ! nc -z localhost 3000 2>/dev/null; then
-        break
-    fi
-    sleep 1
-done
-
 if [[ ${RATE_LIMIT,,} = "true" ]]; then
     OPT_RATE_LIMIT="--rate-limit"
 fi


### PR DESCRIPTION
Remove host_network to fix EADDRINUSE crash loop caused by port 3000 conflict with Grafana. Switch to bridge networking with ingress-only access.