### PR TITLE
fix: PairDrop - non-LSIO standalone pattern (v1.11.2-17)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.2-17 (2026-05-07)
+
+- Switch to non-LSIO pattern (init: true, standalone PairDrop install)
+- Install PairDrop directly instead of using LSIO base image
+- Use 99-run.sh with ha_entrypoint.sh pattern
+
 ## 1.11.2-16 (2026-05-07)
 
 - Rewrite Dockerfile to use sed-based approach (matching sonarr pattern)

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -7,42 +7,28 @@ ARG BUILD_VERSION
 
 USER root
 
-ENV S6_CMD_WAIT_FOR_SERVICES=0 \
-    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_SERVICES_GRACETIME=0
-
-COPY ha_lsio.sh /ha_lsio.sh
-ARG CONFIGLOCATION="/config"
-RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
-
 RUN \
-    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "s|npm start --|node server/index.js|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a DEBUG_MODE=\$(bashio::config 'debug_mode')" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a export DEBUG_MODE" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a source /usr/local/lib/bashio-standalone.sh" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
-    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+    apk add --no-cache nodejs npm && \
+    mkdir -p /app/pairdrop && \
+    if [ -z ${PAIRDROP_RELEASE} ]; then \
+        PAIRDROP_RELEASE=$(curl -sL "https://api.github.com/repos/schlagmichdoch/pairdrop/tags" \
+        | jq -r '.[0].name'); \
+    fi && \
+    curl -o /tmp/pairdrop.tar.gz -L \
+    "https://github.com/schlagmichdoch/PairDrop/archive/refs/tags/${PAIRDROP_RELEASE}.tar.gz" && \
+    tar xf /tmp/pairdrop.tar.gz -C /app/pairdrop/ --strip-components=1 && \
+    cd /app/pairdrop && \
+    npm ci --omit=dev && \
+    rm -rf /tmp/* /root/.cache
 
-COPY rootfs/ /
-RUN find /etc/s6-overlay/s6-rc.d/svc-pairdrop/ -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -exec chmod +x {} \;
-
-ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
-
-COPY ha_automodules.sh /ha_automodules.sh
-RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
-
-COPY ha_autoapps.sh /ha_autoapps.sh
-RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "" && rm /ha_autoapps.sh
-
-ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
 COPY ha_entrypoint.sh /ha_entrypoint.sh
 RUN chmod 777 /ha_entrypoint.sh
 
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+COPY rootfs/ /
+RUN find /etc/cont-init.d/ -type f -exec chmod +x {} \;
 
 ARG BUILD_ARCH
 ARG BUILD_DATE

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -32,7 +32,7 @@ image: ghcr.io/rezusnet/pairdrop-{arch}
 ingress: true
 ingress_port: 3000
 ingress_stream: true
-init: false
+init: true
 map:
   - addon_config:rw
   - media:rw
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-16"
+version: "1.11.2-17"

--- a/pairdrop/rootfs/etc/cont-init.d/99-run.sh
+++ b/pairdrop/rootfs/etc/cont-init.d/99-run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bashio
+set +u
+
+bashio::log.info "Starting PairDrop add-on"
+
+LOCATION="$(bashio::config 'data_location')"
+if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi
+RATE_LIMIT="$(bashio::config 'rate_limit')"
+WS_FALLBACK="$(bashio::config 'ws_fallback')"
+DEBUG_MODE="$(bashio::config 'debug_mode')"
+export DEBUG_MODE
+
+mkdir -p "$LOCATION"
+
+ARGS=()
+if [[ ${RATE_LIMIT,,} = "true" ]]; then
+    ARGS+=("--rate-limit")
+fi
+if [[ ${WS_FALLBACK,,} = "true" ]]; then
+    ARGS+=("--include-ws-fallback")
+fi
+
+bashio::log.info "Data location: ${LOCATION}"
+bashio::log.info "Starting PairDrop server on port 3000..."
+
+cd /app/pairdrop
+exec node server/index.js "${ARGS[@]}"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
@@ -1,8 +1,0 @@
-#!/usr/bin/with-contenv bash
-# shellcheck shell=bash
-for _ in $(seq 1 30); do
-    if ! nc -z localhost 3000 2>/dev/null; then
-        break
-    fi
-    sleep 1
-done


### PR DESCRIPTION
Switch to init:true with standalone PairDrop install, bypassing S6 overlay entirely.