### PR TITLE
fix: PairDrop - remove duplicate node start (v1.11.2-20)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2-20 (2026-05-07)
+
+- Fix 99-run.sh: remove duplicate node server start (was causing EADDRINUSE)
+- 99-run.sh now only does initialization; S6 svc-pairdrop/run starts the server
+
 ## 1.11.2-19 (2026-05-07)
 
 - Remove host_network to fix port 3000 conflict with Grafana

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-19"
+version: "1.11.2-20"

--- a/pairdrop/rootfs/etc/cont-init.d/99-run.sh
+++ b/pairdrop/rootfs/etc/cont-init.d/99-run.sh
@@ -1,27 +1,14 @@
 #!/usr/bin/env bashio
 set +u
 
-bashio::log.info "Starting PairDrop add-on"
+bashio::log.info "Starting PairDrop add-on initialization"
 
 LOCATION="$(bashio::config 'data_location')"
 if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi
-RATE_LIMIT="$(bashio::config 'rate_limit')"
-WS_FALLBACK="$(bashio::config 'ws_fallback')"
 DEBUG_MODE="$(bashio::config 'debug_mode')"
 export DEBUG_MODE
 
 mkdir -p "$LOCATION"
 
-ARGS=()
-if [[ ${RATE_LIMIT,,} = "true" ]]; then
-    ARGS+=("--rate-limit")
-fi
-if [[ ${WS_FALLBACK,,} = "true" ]]; then
-    ARGS+=("--include-ws-fallback")
-fi
-
 bashio::log.info "Data location: ${LOCATION}"
-bashio::log.info "Starting PairDrop server on port 3000..."
-
-cd /app/pairdrop
-exec node server/index.js "${ARGS[@]}"
+bashio::log.info "PairDrop initialization complete"


### PR DESCRIPTION
Remove exec node server/index.js from 99-run.sh. It was starting a SECOND instance that conflicted with the S6 svc-pairdrop service.