### PR TITLE
fix: PairDrop - full patched v1.11.2-22

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.11.2-21 (2026-05-07)
+## 1.11.2-22 (2026-05-07)
 
-- Test: unpatched LSIO image to isolate EADDRINUSE issue
+- Full patched version with --no-cache builder
+- sed: npm start → node server/index.js (fix orphaned child process)
+- 99-run.sh: init only (no duplicate node start)
+- finish script: wait for port 3000 release before restart
+- No host_network (bridge networking to avoid port conflicts)
 
 ## 1.11.2-20 (2026-05-07)
 

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -1,3 +1,81 @@
 ARG BUILD_FROM
 ARG BUILD_VERSION
 FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+USER root
+
+ENV S6_CMD_WAIT_FOR_SERVICES=0 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+COPY ha_lsio.sh /ha_lsio.sh
+ARG CONFIGLOCATION="/config"
+RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
+
+RUN \
+    sed -i "s|contenv bash|contenv bashio|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "s|npm start --|node server/index.js|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "s|/config|\$LOCATION|g" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a if [[ \"\$LOCATION\" = \"null\" || -z \"\$LOCATION\" ]]; then LOCATION=/config; fi" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a LOCATION=\$(bashio::config 'data_location')" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a DEBUG_MODE=\$(bashio::config 'debug_mode')" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a export DEBUG_MODE" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a source /usr/local/lib/bashio-standalone.sh" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run && \
+    sed -i "1a set +u" /etc/s6-overlay/s6-rc.d/svc-pairdrop/run
+
+COPY rootfs/ /
+RUN find /etc/cont-init.d/ /etc/s6-overlay/s6-rc.d/svc-pairdrop/ -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -exec chmod +x {} \;
+
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh"
+
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "" && rm /ha_autoapps.sh
+
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="rezusnet (https://github.com/rezusnet)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/rezusnet" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+ENV HEALTH_PORT="3000" \
+    HEALTH_URL="/"
+HEALTHCHECK \
+    --interval=30s \
+    --retries=5 \
+    --start-period=30s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -2,7 +2,30 @@
 arch:
   - aarch64
   - amd64
-description: PairDrop test - unpatched LSIO image
+description:
+  Cross-platform local file sharing via browser. AirDrop-like peer-to-peer
+  transfers using WebRTC. No cloud upload required.
+devices:
+  - /dev/dri
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  - /dev/nvme0n1p2
+  - /dev/nvme0n1p3
+  - /dev/nvme1n1
+  - /dev/nvme1n1p1
+  - /dev/nvme1n1p2
+  - /dev/nvme1n1p3
+  - /dev/mmcblk
+  - /dev/fuse
+environment:
+  ATTACHED_DEVICES_PERMS: "/dev/dri -type c -o -type f"
 homeassistant: 2024.1.0
 icon: icon.png
 image: ghcr.io/rezusnet/pairdrop-{arch}
@@ -12,11 +35,15 @@ ingress_stream: true
 init: false
 map:
   - addon_config:rw
-name: PairDrop Test
+  - media:rw
+  - share:rw
+  - ssl
+name: PairDrop
 options:
+  env_vars: []
   PGID: 0
   PUID: 0
-  data_location: /config
+  data_location: /share/pairdrop
   TZ: ""
   localdisks: ""
   networkdisks: ""
@@ -26,9 +53,15 @@ options:
   rate_limit: false
   ws_fallback: false
   debug_mode: false
-  env_vars: []
 panel_icon: mdi:share-variant
+ports:
+  3000/tcp: null
+ports_description:
+  3000/tcp: Web UI (optional, ingress recommended)
 schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
   PGID: int
   PUID: int
   data_location: str
@@ -41,9 +74,7 @@ schema:
   rate_limit: bool
   ws_fallback: bool
   debug_mode: bool
-  env_vars:
-    - name: match(^[A-Za-z0-9_]+$)
-      value: str?
 slug: pairdrop
+udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-21"
+version: "1.11.2-22"

--- a/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
+++ b/pairdrop/rootfs/etc/s6-overlay/s6-rc.d/svc-pairdrop/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+for _ in $(seq 1 30); do
+    if ! nc -z localhost 3000 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done


### PR DESCRIPTION
Complete fix: node direct (no npm), finish script with port wait, no duplicate node start, bridge networking.