### PR TITLE
fix: PairDrop - DELETE LSIO svc-pairdrop (v1.11.2-27)

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.2-27 (2026-05-07)
+
+- DELETE LSIO s6-overlay svc-pairdrop service from image
+- Prevents LSIO's original `npm start` from running alongside our service
+- Root cause: LSIO s6-overlay always starts original service, COPY doesn't remove files
+
 ## 1.11.2-26 (2026-05-07)
 
 - Use Supervisor-managed init (`init: true`) instead of LSIO S6 overlay

--- a/pairdrop/Dockerfile
+++ b/pairdrop/Dockerfile
@@ -4,6 +4,8 @@ FROM ${BUILD_FROM}
 
 USER root
 
+RUN rm -rf /etc/s6-overlay/s6-rc.d/svc-pairdrop /etc/s6-overlay/s6-rc.d/user/contents.d/svc-pairdrop
+
 COPY rootfs/ /
 RUN find /etc/cont-init.d/ /etc/services.d/ -type f -exec chmod +x {} \;
 

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-26"
+version: "1.11.2-27"


### PR DESCRIPTION
Delete LSIO's s6-overlay svc-pairdrop to prevent original npm start from running.