### PR TITLE
fix: PairDrop - fix 99-run.sh, panel_icon (v1.11.2-33)

### DIFF
--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -39,6 +39,7 @@ map:
   - share:rw
   - ssl
 name: PairDrop
+panel_icon: mdi:share-variant
 options:
   env_vars: []
   PGID: 0
@@ -53,7 +54,6 @@ options:
   rate_limit: false
   ws_fallback: false
   debug_mode: false
-panel_icon: mdi:share-variant
 ports:
   3000/tcp: null
 ports_description:
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-32"
+version: "1.11.2-33"

--- a/pairdrop/rootfs/etc/cont-init.d/99-run.sh
+++ b/pairdrop/rootfs/etc/cont-init.d/99-run.sh
@@ -1,14 +1,3 @@
-#!/usr/bin/env bashio
-set +u
-
-bashio::log.info "Starting PairDrop add-on initialization"
-
-LOCATION="$(bashio::config 'data_location')"
-if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then LOCATION=/config; fi
-DEBUG_MODE="$(bashio::config 'debug_mode')"
-export DEBUG_MODE
-
+#!/usr/bin/with-contenv bash
+LOCATION="/config"
 mkdir -p "$LOCATION"
-
-bashio::log.info "Data location: ${LOCATION}"
-bashio::log.info "PairDrop initialization complete"


### PR DESCRIPTION
Fix 99-run.sh shebang and permission, move panel_icon to top-level.