### PR TITLE
fix: MinIO - hardcode ports, expose S3 API + Console, fix updater

### DIFF
--- a/.github/scripts/updater.sh
+++ b/.github/scripts/updater.sh
@@ -194,7 +194,7 @@ verify_tag_exists() {
         return $?
     fi
 
-    if [[ "$domain" == *"docker.io"* ]] || [[ "$image_tag" != *"/"* ]] || [[ "$domain" == *"lscr.io"* ]]; then
+    if [[ "$domain" != *"ghcr.io"* ]]; then
         local normalized_repo="${repo}"
         [[ "$normalized_repo" != *"/"* ]] && normalized_repo="library/${normalized_repo}"
         local http_code

--- a/minio/config.yaml
+++ b/minio/config.yaml
@@ -22,22 +22,15 @@ options:
   access_key: minioadmin
   secret_key: minioadmin
   data_location: /share/minio
-  api_port: 9000
-  console_port: 9001
   TZ: ""
   env_vars: []
 ports:
-  9000/tcp: null
-  9001/tcp: null
-ports_description:
-  9000/tcp: S3 API endpoint (optional, enable for external access)
-  9001/tcp: Web Console (optional, ingress recommended)
+  9000/tcp: 9000
+  9001/tcp: 9001
 schema:
   access_key: str
   secret_key: password
   data_location: str
-  api_port: port
-  console_port: port
   TZ: str?
   env_vars:
     - name: match(^[A-Za-z0-9_]+$)

--- a/minio/rootfs/etc/cont-init.d/99-run.sh
+++ b/minio/rootfs/etc/cont-init.d/99-run.sh
@@ -12,32 +12,18 @@ fi
 ACCESS_KEY="$(bashio::config 'access_key')"
 SECRET_KEY="$(bashio::config 'secret_key')"
 DATA_LOCATION="$(bashio::config 'data_location')"
-API_PORT="$(bashio::config 'api_port')"
-CONSOLE_PORT="$(bashio::config 'console_port')"
 
 export MINIO_ROOT_USER="${ACCESS_KEY}"
 export MINIO_ROOT_PASSWORD="${SECRET_KEY}"
 
 mkdir -p "${DATA_LOCATION}"
 
-CONSOLE_INTERNAL=$((CONSOLE_PORT + 1))
-
-sed -i "s|proxy_pass http://127.0.0.1:[0-9]*|proxy_pass http://127.0.0.1:${CONSOLE_INTERNAL}|" /etc/nginx/nginx.conf
-
-if [ "${CONSOLE_PORT}" = "9001" ]; then
-    sed -i "s/listen [0-9]*/listen 9001/" /etc/nginx/nginx.conf
-    nginx -c /etc/nginx/nginx.conf &
-    bashio::log.info "nginx reverse proxy on :9001 -> :${CONSOLE_INTERNAL} (ingress enabled)"
-else
-    sed -i "s/listen [0-9]*/listen ${CONSOLE_PORT}/" /etc/nginx/nginx.conf
-    nginx -c /etc/nginx/nginx.conf &
-    bashio::log.info "nginx reverse proxy on :${CONSOLE_PORT} -> :${CONSOLE_INTERNAL} (ingress disabled, use direct port)"
-fi
+nginx -c /etc/nginx/nginx.conf &
+bashio::log.info "nginx reverse proxy started on :9001 -> :9002"
 
 bashio::log.info "Data location: ${DATA_LOCATION}"
-bashio::log.info "API port: ${API_PORT}, Console port: ${CONSOLE_PORT}"
 bashio::log.info "MinIO initialization complete"
 
 exec minio server "${DATA_LOCATION}" \
-    --console-address ":${CONSOLE_INTERNAL}" \
-    --address ":${API_PORT}"
+    --console-address ":9002" \
+    --address ":9000"


### PR DESCRIPTION
## Summary
- Hardcode MinIO ports (9000 S3 API, 9001 Console via nginx, 9002 internal Console) instead of configurable port options
- Expose both ports in `ports` section (no more redundant port options in `options`/`schema`)
- Fix `verify_tag_exists` in updater.sh to correctly identify Docker Hub images (pgsty/minio was being skipped)