### PR TITLE
fix: make prebuild-sanitize non-blocking for protected branches

### DIFF
--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -74,6 +74,7 @@ jobs:
     if: ${{ needs.detect-changed-addons.outputs.changedAddons != '' && needs.detect-changed-addons.outputs.changedAddons != '[]' }}
     needs: detect-changed-addons
     runs-on: [self-hosted, linux, arm64]
+    continue-on-error: true
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to `prebuild-sanitize` job so that when the sanitize step cannot push to protected master, the build pipeline still proceeds
- Previous merge (#329) had MinIO changes but the build was blocked because sanitize tried to push a chmod fix to protected master