### PR TITLE
fix: MinIO Console WebSocket Origin header for ingress

### DIFF
--- a/minio/rootfs/etc/nginx/nginx.conf
+++ b/minio/rootfs/etc/nginx/nginx.conf
@@ -14,10 +14,11 @@ http {
 
         location / {
             proxy_pass http://127.0.0.1:9002;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Origin http://127.0.0.1:9002;
 
             sub_filter '<base href="/"' '<base href="./"';
             sub_filter_once on;
@@ -27,7 +28,12 @@ http {
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
         }
+    }
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
     }
 }


### PR DESCRIPTION
## Summary
- Fix MinIO Console WebSocket `/ws/objectManager` returning 403 through ingress
- Root cause: Console's WebSocket upgrader checks `Origin` header against its own address (`127.0.0.1:9002`), but ingress sends a different origin
- Fix: nginx rewrites `Origin` header to `http://127.0.0.1:9002` before proxying to Console
- Also fix `Connection` header mapping to use `$connection_upgrade` map (proper WebSocket upgrade handling)
- Also fix `Host` header to use `$http_host` (preserves port info)