### PR TITLE
fix: MinIO WebSocket Origin - force image refresh

### DIFF
--- a/minio/config.yaml
+++ b/minio/config.yaml
@@ -37,4 +37,4 @@ schema:
       value: str?
 slug: minio
 url: https://silo.pigsty.io
-version: RELEASE.2026-04-17T00-00-00Z
+version: RELEASE.2026-04-17T00-00-00Z.1


### PR DESCRIPTION
Bump version to force HAOS to pull new image with nginx Origin rewrite fix.