### PR TITLE
fix: MinIO WebSocket - remove Origin header

### DIFF
--- a/minio/rootfs/etc/nginx/nginx.conf
+++ b/minio/rootfs/etc/nginx/nginx.conf
@@ -1,5 +1,5 @@
 worker_processes 1;
-error_log /dev/null;
+error_log stderr;
 pid /tmp/nginx.pid;
 
 events {
@@ -18,7 +18,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Origin http://127.0.0.1:9002;
+            proxy_set_header Origin "";
 
             sub_filter '<base href="/"' '<base href="./"';
             sub_filter_once on;


### PR DESCRIPTION
Remove Origin header in nginx proxy to fix Console WebSocket 403. Go websocket library accepts empty Origin.