### PR TITLE
chore: update upstream versions 2026-05-27

### DIFF
--- a/lightrag/CHANGELOG.md
+++ b/lightrag/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0rc3 (2026-05-27)
+
+- Update to upstream v1.5.0rc3
+
 ## 1.5.0rc2 (2026-05-24)
 
 - Update to upstream v1.5.0rc2

--- a/lightrag/build.json
+++ b/lightrag/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.0rc2",
-    "amd64": "ghcr.io/hkuds/lightrag:v1.5.0rc2"
+    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.0rc3",
+    "amd64": "ghcr.io/hkuds/lightrag:v1.5.0rc3"
   }
 }

--- a/lightrag/config.yaml
+++ b/lightrag/config.yaml
@@ -68,4 +68,4 @@ schema:
       value: str?
 slug: lightrag
 url: https://github.com/HKUDS/LightRAG
-version: "1.5.0rc2"
+version: "1.5.0rc3"

--- a/lightrag/updater.json
+++ b/lightrag/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-05-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "lightrag",
@@ -7,5 +7,5 @@
   "tag_keep_v": true,
   "tag_strategy": "direct",
   "upstream_repo": "HKUDS/LightRAG",
-  "upstream_version": "v1.5.0rc2"
+  "upstream_version": "v1.5.0rc3"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.11 (2026-05-27)
+
+- Update to upstream v1.15.11
+
 ## 1.15.10 (2026-05-24)
 
 - Update to upstream v1.15.10

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.15.10"
+version: "1.15.11"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-24",
+  "last_update": "2026-05-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.15.10"
+  "upstream_version": "v1.15.11"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1-r1-ls345 (2026-05-27)
+
+- Update to upstream 4.1.1-r1-ls345
+
 ## 4.1.1-r1-ls344 (2026-05-24)
 
 - Update to upstream 4.1.1-r1-ls344

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.1-r1-ls344"
+version: "4.1.1-r1-ls345"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-05-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.1-r1-ls344"
+  "upstream_version": "4.1.1-r1-ls345"
 }


### PR DESCRIPTION
## Upstream version updates

- **lightrag**: `v1.5.0rc2` → `v1.5.0rc3`
- **opencode**: `v1.15.10` → `v1.15.11`
- **transmission**: `4.1.1-r1-ls344` → `4.1.1-r1-ls345`


Auto-generated by the daily updater workflow.