### PR TITLE
chore: update upstream versions 2026-05-29

### DIFF
--- a/audiobookshelf/CHANGELOG.md
+++ b/audiobookshelf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.35.1 (2026-05-29)
+
+- Update to upstream v2.35.1
+
 ## 2.35.0 (2026-05-19)
 
 - Update to upstream v2.35.0

--- a/audiobookshelf/build.json
+++ b/audiobookshelf/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/advplyr/audiobookshelf:2.35.0",
-    "amd64": "ghcr.io/advplyr/audiobookshelf:2.35.0"
+    "aarch64": "ghcr.io/advplyr/audiobookshelf:2.35.1",
+    "amd64": "ghcr.io/advplyr/audiobookshelf:2.35.1"
   }
 }

--- a/audiobookshelf/config.yaml
+++ b/audiobookshelf/config.yaml
@@ -70,4 +70,4 @@ schema:
       value: str?
 slug: audiobookshelf
 url: https://www.audiobookshelf.org/
-version: "2.35.0"
+version: "2.35.1"

--- a/audiobookshelf/updater.json
+++ b/audiobookshelf/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-19",
+  "last_update": "2026-05-29",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "audiobookshelf",
@@ -8,5 +8,5 @@
   "tag_keep_v": false,
   "tag_strategy": "direct",
   "upstream_repo": "advplyr/audiobookshelf",
-  "upstream_version": "v2.35.0"
+  "upstream_version": "v2.35.1"
 }

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.10-ls194 (2026-05-29)
+
+- Update to upstream v4.5.10-ls194
+
 ## 4.5.10-ls193 (2026-05-24)
 
 - Update to upstream v4.5.10-ls193

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.5.10-ls193"
+version: "4.5.10-ls194"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-05-29",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.5.10-ls193"
+  "upstream_version": "v4.5.10-ls194"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.12 (2026-05-29)
+
+- Update to upstream v1.15.12
+
 ## 1.15.11 (2026-05-27)
 
 - Update to upstream v1.15.11

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.15.11"
+version: "1.15.12"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-27",
+  "last_update": "2026-05-29",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.15.11"
+  "upstream_version": "v1.15.12"
 }


### PR DESCRIPTION
## Upstream version updates

- **audiobookshelf**: `v2.35.0` → `v2.35.1`
- **mastodon**: `v4.5.10-ls193` → `v4.5.10-ls194`
- **opencode**: `v1.15.11` → `v1.15.12`


Auto-generated by the daily updater workflow.