### PR TITLE
chore: update upstream versions 2026-05-30

### DIFF
--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## pr-29948-screenshots (2026-05-30)
+
+- Update to upstream pr-29948-screenshots
+
 ## 1.15.12 (2026-05-29)
 
 - Update to upstream v1.15.12

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.15.12"
+version: "pr-29948-screenshots"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-29",
+  "last_update": "2026-05-30",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.15.12"
+  "upstream_version": "pr-29948-screenshots"
 }


### PR DESCRIPTION
## Upstream version updates

- **opencode**: `v1.15.12` → `pr-29948-screenshots`


Auto-generated by the daily updater workflow.