### PR TITLE
chore: update upstream versions 2026-05-31

### DIFF
--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.13 (2026-05-31)
+
+- Update to upstream v1.15.13
+
 ## pr-29948-screenshots (2026-05-30)
 
 - Update to upstream pr-29948-screenshots

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "pr-29948-screenshots"
+version: "1.15.13"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-30",
+  "last_update": "2026-05-31",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "pr-29948-screenshots"
+  "upstream_version": "v1.15.13"
 }


### PR DESCRIPTION
## Upstream version updates

- **opencode**: `pr-29948-screenshots` → `v1.15.13`


Auto-generated by the daily updater workflow.