### PR TITLE
chore: update upstream versions 2026-06-01

### DIFF
--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-2.4.0.5391-ls263 (2026-06-01)
+
+- Update to upstream develop-2.4.0.5391-ls263
+
 ## 2.3.5.5327-ls147 (2026-05-24)
 
 - Update to upstream 2.3.5.5327-ls147

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "2.3.5.5327-ls147"
+version: "develop-2.4.0.5391-ls263"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-06-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "2.3.5.5327-ls147"
+  "upstream_version": "develop-2.4.0.5391-ls263"
 }

--- a/radarr/CHANGELOG.md
+++ b/radarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-6.2.1.10437-ls256 (2026-06-01)
+
+- Update to upstream develop-6.2.1.10437-ls256
+
 ## 6.1.1.10360-ls303 (2026-05-19)
 
 - Update to upstream 6.1.1.10360-ls303

--- a/radarr/config.yaml
+++ b/radarr/config.yaml
@@ -82,4 +82,4 @@ schema:
 slug: radarr
 udev: true
 url: https://radarr.video
-version: "6.1.1.10360-ls303"
+version: "develop-6.2.1.10437-ls256"

--- a/radarr/updater.json
+++ b/radarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-19",
+  "last_update": "2026-06-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "radarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-radarr",
-  "upstream_version": "6.1.1.10360-ls303"
+  "upstream_version": "develop-6.2.1.10437-ls256"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1-r1-ls346 (2026-06-01)
+
+- Update to upstream 4.1.1-r1-ls346
+
 ## 4.1.1-r1-ls345 (2026-05-27)
 
 - Update to upstream 4.1.1-r1-ls345

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.1-r1-ls345"
+version: "4.1.1-r1-ls346"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-27",
+  "last_update": "2026-06-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.1-r1-ls345"
+  "upstream_version": "4.1.1-r1-ls346"
 }


### PR DESCRIPTION
## Upstream version updates

- **prowlarr**: `2.3.5.5327-ls147` → `develop-2.4.0.5391-ls263`
- **radarr**: `6.1.1.10360-ls303` → `develop-6.2.1.10437-ls256`
- **transmission**: `4.1.1-r1-ls345` → `4.1.1-r1-ls346`


Auto-generated by the daily updater workflow.