### PR TITLE
chore: update upstream versions 2026-06-03

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.6-ls350 (2026-06-03)
+
+- Update to upstream v1.5.6-ls350
+
 ## 1.5.6-ls349 (2026-05-24)
 
 - Update to upstream v1.5.6-ls349

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "1.5.6-ls349"
+version: "1.5.6-ls350"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-06-03",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "v1.5.6-ls349"
+  "upstream_version": "v1.5.6-ls350"
 }

--- a/lightrag/CHANGELOG.md
+++ b/lightrag/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0 (2026-06-03)
+
+- Update to upstream v1.5.0
+
 ## 1.5.0rc3 (2026-05-27)
 
 - Update to upstream v1.5.0rc3

--- a/lightrag/build.json
+++ b/lightrag/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.0rc3",
-    "amd64": "ghcr.io/hkuds/lightrag:v1.5.0rc3"
+    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.0",
+    "amd64": "ghcr.io/hkuds/lightrag:v1.5.0"
   }
 }

--- a/lightrag/config.yaml
+++ b/lightrag/config.yaml
@@ -68,4 +68,4 @@ schema:
       value: str?
 slug: lightrag
 url: https://github.com/HKUDS/LightRAG
-version: "1.5.0rc3"
+version: "1.5.0"

--- a/lightrag/updater.json
+++ b/lightrag/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-05-27",
+  "last_update": "2026-06-03",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "lightrag",
@@ -7,5 +7,5 @@
   "tag_keep_v": true,
   "tag_strategy": "direct",
   "upstream_repo": "HKUDS/LightRAG",
-  "upstream_version": "v1.5.0rc3"
+  "upstream_version": "v1.5.0"
 }

--- a/valkey8/CHANGELOG.md
+++ b/valkey8/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.8 (2026-06-03)
+
+- Update to upstream 8.1.8
+
 ## 8.1.7 (2026-05-12)
 
 - Update to upstream 8.1.7

--- a/valkey8/build.json
+++ b/valkey8/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "valkey/valkey:8.1.7-alpine",
-    "amd64": "valkey/valkey:8.1.7-alpine"
+    "aarch64": "valkey/valkey:8.1.8-alpine",
+    "amd64": "valkey/valkey:8.1.8-alpine"
   }
 }

--- a/valkey8/config.yaml
+++ b/valkey8/config.yaml
@@ -40,4 +40,4 @@ schema:
       value: str?
 slug: valkey8
 url: https://valkey.io
-version: "8.1.7"
+version: "8.1.8"

--- a/valkey8/updater.json
+++ b/valkey8/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-05-12",
+  "last_update": "2026-06-03",
   "major_version": "8",
   "paused": false,
   "slug": "valkey8",
@@ -7,5 +7,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "valkey-io/valkey",
-  "upstream_version": "8.1.7"
+  "upstream_version": "8.1.8"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `v1.5.6-ls349` → `v1.5.6-ls350`
- **lightrag**: `v1.5.0rc3` → `v1.5.0`
- **valkey8**: `8.1.7` → `8.1.8`


Auto-generated by the daily updater workflow.