### PR TITLE
chore: update upstream versions 2026-06-04

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.10 (2026-06-04)
+
+- Update to upstream v2.63.10
+
 ## 2.63.5 (2026-05-24)
 
 - Update to upstream v2.63.5

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.5-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.5-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.10-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.10-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.5"
+version: "2.63.10"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-24",
+  "last_update": "2026-06-04",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.5"
+  "upstream_version": "v2.63.10"
 }

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0 (2026-06-04)
+
+- Update to upstream v3.4.0
+
 ## 3.0.23 (2026-05-19)
 
 - Update to upstream v3.0.23

--- a/haproxy/build.json
+++ b/haproxy/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "haproxy:3.0.23-alpine",
-    "amd64": "haproxy:3.0.23-alpine"
+    "aarch64": "haproxy:3.4.0-alpine",
+    "amd64": "haproxy:3.4.0-alpine"
   }
 }

--- a/haproxy/config.yaml
+++ b/haproxy/config.yaml
@@ -31,4 +31,4 @@ slug: haproxy
 startup: application
 boot: auto
 url: https://www.haproxy.org/
-version: "3.0.23"
+version: "3.4.0"

--- a/haproxy/updater.json
+++ b/haproxy/updater.json
@@ -1,6 +1,6 @@
 {
   "dockerhub_tag_filter": "-alpine",
-  "last_update": "2026-05-19",
+  "last_update": "2026-06-04",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "haproxy",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "library/haproxy",
-  "upstream_version": "v3.0.23"
+  "upstream_version": "v3.4.0"
 }

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.11-ls195 (2026-06-04)
+
+- Update to upstream v4.5.11-ls195
+
 ## 4.5.10-ls194 (2026-05-29)
 
 - Update to upstream v4.5.10-ls194

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.5.10-ls194"
+version: "4.5.11-ls195"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-29",
+  "last_update": "2026-06-04",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.5.10-ls194"
+  "upstream_version": "v4.5.11-ls195"
 }

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.5.5327-ls148 (2026-06-04)
+
+- Update to upstream 2.3.5.5327-ls148
+
 ## develop-2.4.0.5391-ls263 (2026-06-01)
 
 - Update to upstream develop-2.4.0.5391-ls263

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "develop-2.4.0.5391-ls263"
+version: "2.3.5.5327-ls148"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-01",
+  "last_update": "2026-06-04",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "develop-2.4.0.5391-ls263"
+  "upstream_version": "2.3.5.5327-ls148"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-r0-ls347 (2026-06-04)
+
+- Update to upstream 4.1.2-r0-ls347
+
 ## 4.1.1-r1-ls346 (2026-06-01)
 
 - Update to upstream 4.1.1-r1-ls346

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.1-r1-ls346"
+version: "4.1.2-r0-ls347"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-01",
+  "last_update": "2026-06-04",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.1-r1-ls346"
+  "upstream_version": "4.1.2-r0-ls347"
 }


### PR DESCRIPTION
## Upstream version updates

- **filebrowser**: `v2.63.5` → `v2.63.10`
- **haproxy**: `v3.0.23` → `v3.4.0`
- **mastodon**: `v4.5.10-ls194` → `v4.5.11-ls195`
- **prowlarr**: `develop-2.4.0.5391-ls263` → `2.3.5.5327-ls148`
- **transmission**: `4.1.1-r1-ls346` → `4.1.2-r0-ls347`


Auto-generated by the daily updater workflow.