### PR TITLE
chore: update upstream versions 2026-06-05

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.12 (2026-06-05)
+
+- Update to upstream v2.63.12
+
 ## 2.63.10 (2026-06-04)
 
 - Update to upstream v2.63.10

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.10-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.10-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.12-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.12-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.10"
+version: "2.63.12"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-04",
+  "last_update": "2026-06-05",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.10"
+  "upstream_version": "v2.63.12"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0 (2026-06-05)
+
+- Update to upstream v1.16.0
+
 ## 1.15.13 (2026-05-31)
 
 - Update to upstream v1.15.13

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.15.13"
+version: "1.16.0"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-05-31",
+  "last_update": "2026-06-05",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.15.13"
+  "upstream_version": "v1.16.0"
 }


### PR DESCRIPTION
## Upstream version updates

- **filebrowser**: `v2.63.10` → `v2.63.12`
- **opencode**: `v1.15.13` → `v1.16.0`


Auto-generated by the daily updater workflow.