### PR TITLE
chore: update upstream versions 2026-06-07

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.13 (2026-06-07)
+
+- Update to upstream v2.63.13
+
 ## 2.63.12 (2026-06-05)
 
 - Update to upstream v2.63.12

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.12-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.12-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.13-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.13-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.12"
+version: "2.63.13"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-05",
+  "last_update": "2026-06-07",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.12"
+  "upstream_version": "v2.63.13"
 }


### PR DESCRIPTION
## Upstream version updates

- **filebrowser**: `v2.63.12` → `v2.63.13`


Auto-generated by the daily updater workflow.