### PR TITLE
chore: update upstream versions 2026-06-12

### DIFF
--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.11-ls196 (2026-06-12)
+
+- Update to upstream v4.5.11-ls196
+
 ## 4.5.11-ls195 (2026-06-04)
 
 - Update to upstream v4.5.11-ls195

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.5.11-ls195"
+version: "4.5.11-ls196"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-04",
+  "last_update": "2026-06-12",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.5.11-ls195"
+  "upstream_version": "v4.5.11-ls196"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.4 (2026-06-12)
+
+- Update to upstream v1.17.4
+
 ## 1.17.3 (2026-06-11)
 
 - Update to upstream v1.17.3

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.3"
+version: "1.17.4"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-11",
+  "last_update": "2026-06-12",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.3"
+  "upstream_version": "v1.17.4"
 }


### PR DESCRIPTION
## Upstream version updates

- **mastodon**: `v4.5.11-ls195` → `v4.5.11-ls196`
- **opencode**: `v1.17.3` → `v1.17.4`


Auto-generated by the daily updater workflow.