### PR TITLE
chore: update upstream versions 2026-06-14

### DIFF
--- a/lightrag/CHANGELOG.md
+++ b/lightrag/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.3 (2026-06-14)
+
+- Update to upstream v1.5.3
+
 ## 1.5.2 (2026-06-11)
 
 - Update to upstream v1.5.2

--- a/lightrag/build.json
+++ b/lightrag/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.2",
-    "amd64": "ghcr.io/hkuds/lightrag:v1.5.2"
+    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.3",
+    "amd64": "ghcr.io/hkuds/lightrag:v1.5.3"
   }
 }

--- a/lightrag/config.yaml
+++ b/lightrag/config.yaml
@@ -68,4 +68,4 @@ schema:
       value: str?
 slug: lightrag
 url: https://github.com/HKUDS/LightRAG
-version: "1.5.2"
+version: "1.5.3"

--- a/lightrag/updater.json
+++ b/lightrag/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-06-11",
+  "last_update": "2026-06-14",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "lightrag",
@@ -7,5 +7,5 @@
   "tag_keep_v": true,
   "tag_strategy": "direct",
   "upstream_repo": "HKUDS/LightRAG",
-  "upstream_version": "v1.5.2"
+  "upstream_version": "v1.5.3"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.6 (2026-06-14)
+
+- Update to upstream v1.17.6
+
 ## 1.17.4 (2026-06-12)
 
 - Update to upstream v1.17.4

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.4"
+version: "1.17.6"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-12",
+  "last_update": "2026-06-14",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.4"
+  "upstream_version": "v1.17.6"
 }


### PR DESCRIPTION
## Upstream version updates

- **lightrag**: `v1.5.2` → `v1.5.3`
- **opencode**: `v1.17.4` → `v1.17.6`


Auto-generated by the daily updater workflow.