### PR TITLE
chore: update upstream versions 2026-06-17

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.6-ls351 (2026-06-17)
+
+- Update to upstream v1.5.6-ls351
+
 ## 1.5.6-ls350 (2026-06-03)
 
 - Update to upstream v1.5.6-ls350

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "1.5.6-ls350"
+version: "1.5.6-ls351"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-03",
+  "last_update": "2026-06-17",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "v1.5.6-ls350"
+  "upstream_version": "v1.5.6-ls351"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-r0-ls349 (2026-06-17)
+
+- Update to upstream 4.1.2-r0-ls349
+
 ## 4.1.2-r0-ls348 (2026-06-10)
 
 - Update to upstream 4.1.2-r0-ls348

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.2-r0-ls348"
+version: "4.1.2-r0-ls349"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-10",
+  "last_update": "2026-06-17",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.2-r0-ls348"
+  "upstream_version": "4.1.2-r0-ls349"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `v1.5.6-ls350` → `v1.5.6-ls351`
- **transmission**: `4.1.2-r0-ls348` → `4.1.2-r0-ls349`


Auto-generated by the daily updater workflow.