### PR TITLE
chore: update upstream versions 2026-06-19

### DIFF
--- a/minio/CHANGELOG.md
+++ b/minio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## RELEASE.2026-06-18T00-00-00Z.2 (2026-06-19)
+
+- Update to upstream RELEASE.2026-06-18T00-00-00Z
+
 ## RELEASE.2026-04-17T00-00-00Z (2026-05-10)
 
 - Initial release based on pgsty/minio (Silo) RELEASE.2026-04-17T00-00-00Z

--- a/minio/build.json
+++ b/minio/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "pgsty/minio:RELEASE.2026-04-17T00-00-00Z",
-    "amd64": "pgsty/minio:RELEASE.2026-04-17T00-00-00Z"
+    "aarch64": "pgsty/minio:RELEASE.2026-06-18T00-00-00Z",
+    "amd64": "pgsty/minio:RELEASE.2026-06-18T00-00-00Z"
   }
 }

--- a/minio/config.yaml
+++ b/minio/config.yaml
@@ -37,4 +37,4 @@ schema:
       value: str?
 slug: minio
 url: https://silo.pigsty.io
-version: RELEASE.2026-04-17T00-00-00Z.2
+version: "RELEASE.2026-06-18T00-00-00Z.2"

--- a/minio/updater.json
+++ b/minio/updater.json
@@ -1,10 +1,10 @@
 {
   "build_suffix": ".2",
-  "last_update": "2026-05-10",
+  "last_update": "2026-06-19",
   "paused": false,
   "slug": "minio",
   "source": "github",
   "tag_strategy": "direct",
   "upstream_repo": "pgsty/minio",
-  "upstream_version": "RELEASE.2026-04-17T00-00-00Z"
+  "upstream_version": "RELEASE.2026-06-18T00-00-00Z"
 }


### PR DESCRIPTION
## Upstream version updates

- **minio**: `RELEASE.2026-04-17T00-00-00Z` → `RELEASE.2026-06-18T00-00-00Z`


Auto-generated by the daily updater workflow.