### PR TITLE
chore: update upstream versions 2026-06-20

### DIFF
--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.24 (2026-06-20)
+
+- Update to upstream v2.8.24
+
 ## 2.6.29 (2026-06-18)
 
 - Update to upstream v2.6.29

--- a/haproxy/build.json
+++ b/haproxy/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "haproxy:2.6.29-alpine",
-    "amd64": "haproxy:2.6.29-alpine"
+    "aarch64": "haproxy:2.8.24-alpine",
+    "amd64": "haproxy:2.8.24-alpine"
   }
 }

--- a/haproxy/config.yaml
+++ b/haproxy/config.yaml
@@ -31,4 +31,4 @@ slug: haproxy
 startup: application
 boot: auto
 url: https://www.haproxy.org/
-version: "2.6.29"
+version: "2.8.24"

--- a/haproxy/updater.json
+++ b/haproxy/updater.json
@@ -1,6 +1,6 @@
 {
   "dockerhub_tag_filter": "-alpine",
-  "last_update": "2026-06-18",
+  "last_update": "2026-06-20",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "haproxy",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "library/haproxy",
-  "upstream_version": "v2.6.29"
+  "upstream_version": "v2.8.24"
 }


### PR DESCRIPTION
## Upstream version updates

- **haproxy**: `v2.6.29` → `v2.8.24`


Auto-generated by the daily updater workflow.