### PR TITLE
chore: update upstream versions 2026-06-21

### DIFF
--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.9 (2026-06-21)
+
+- Update to upstream v1.17.9
+
 ## 1.17.8 (2026-06-18)
 
 - Update to upstream v1.17.8

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.8"
+version: "1.17.9"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-18",
+  "last_update": "2026-06-21",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.8"
+  "upstream_version": "v1.17.9"
 }


### PR DESCRIPTION
## Upstream version updates

- **opencode**: `v1.17.8` → `v1.17.9`


Auto-generated by the daily updater workflow.