### PR TITLE
chore: update upstream versions 2026-06-25

### DIFF
--- a/lightrag/CHANGELOG.md
+++ b/lightrag/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.4 (2026-06-25)
+
+- Update to upstream v1.5.4
+
 ## 1.5.3 (2026-06-14)
 
 - Update to upstream v1.5.3

--- a/lightrag/build.json
+++ b/lightrag/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.3",
-    "amd64": "ghcr.io/hkuds/lightrag:v1.5.3"
+    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.4",
+    "amd64": "ghcr.io/hkuds/lightrag:v1.5.4"
   }
 }

--- a/lightrag/config.yaml
+++ b/lightrag/config.yaml
@@ -68,4 +68,4 @@ schema:
       value: str?
 slug: lightrag
 url: https://github.com/HKUDS/LightRAG
-version: "1.5.3"
+version: "1.5.4"

--- a/lightrag/updater.json
+++ b/lightrag/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-06-14",
+  "last_update": "2026-06-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "lightrag",
@@ -7,5 +7,5 @@
   "tag_keep_v": true,
   "tag_strategy": "direct",
   "upstream_repo": "HKUDS/LightRAG",
-  "upstream_version": "v1.5.3"
+  "upstream_version": "v1.5.4"
 }

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.1-ls198 (2026-06-25)
+
+- Update to upstream v4.6.1-ls198
+
 ## 4.6.0-ls197 (2026-06-18)
 
 - Update to upstream v4.6.0-ls197

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.6.0-ls197"
+version: "4.6.1-ls198"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-18",
+  "last_update": "2026-06-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.6.0-ls197"
+  "upstream_version": "v4.6.1-ls198"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.10 (2026-06-25)
+
+- Update to upstream v1.17.10
+
 ## 1.17.9 (2026-06-21)
 
 - Update to upstream v1.17.9

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.9"
+version: "1.17.10"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-21",
+  "last_update": "2026-06-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.9"
+  "upstream_version": "v1.17.10"
 }

--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-4.0.18.2976-ls175 (2026-06-25)
+
+- Update to upstream develop-4.0.18.2976-ls175
+
 ## 4.0.17.2952-ls314 (2026-06-13)
 
 - Update to upstream 4.0.17.2952-ls314

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -82,4 +82,4 @@ schema:
 slug: sonarr
 udev: true
 url: https://sonarr.tv
-version: "4.0.17.2952-ls314"
+version: "develop-4.0.18.2976-ls175"

--- a/sonarr/updater.json
+++ b/sonarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-13",
+  "last_update": "2026-06-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "sonarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-sonarr",
-  "upstream_version": "4.0.17.2952-ls314"
+  "upstream_version": "develop-4.0.18.2976-ls175"
 }


### PR DESCRIPTION
## Upstream version updates

- **lightrag**: `v1.5.3` → `v1.5.4`
- **mastodon**: `v4.6.0-ls197` → `v4.6.1-ls198`
- **opencode**: `v1.17.9` → `v1.17.10`
- **sonarr**: `4.0.17.2952-ls314` → `develop-4.0.18.2976-ls175`


Auto-generated by the daily updater workflow.