### PR TITLE
chore: update upstream versions 2026-06-26

### DIFF
--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.1 (2026-06-26)
+
+- Update to upstream v3.4.1
+
 ## 2.8.24 (2026-06-20)
 
 - Update to upstream v2.8.24

--- a/haproxy/build.json
+++ b/haproxy/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "haproxy:2.8.24-alpine",
-    "amd64": "haproxy:2.8.24-alpine"
+    "aarch64": "haproxy:3.4.1-alpine",
+    "amd64": "haproxy:3.4.1-alpine"
   }
 }

--- a/haproxy/config.yaml
+++ b/haproxy/config.yaml
@@ -31,4 +31,4 @@ slug: haproxy
 startup: application
 boot: auto
 url: https://www.haproxy.org/
-version: "2.8.24"
+version: "3.4.1"

--- a/haproxy/updater.json
+++ b/haproxy/updater.json
@@ -1,6 +1,6 @@
 {
   "dockerhub_tag_filter": "-alpine",
-  "last_update": "2026-06-20",
+  "last_update": "2026-06-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "haproxy",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "library/haproxy",
-  "upstream_version": "v2.8.24"
+  "upstream_version": "v3.4.1"
 }

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.2-ls198 (2026-06-26)
+
+- Update to upstream v4.6.2-ls198
+
 ## 4.6.1-ls198 (2026-06-25)
 
 - Update to upstream v4.6.1-ls198

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.6.1-ls198"
+version: "4.6.2-ls198"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-25",
+  "last_update": "2026-06-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.6.1-ls198"
+  "upstream_version": "v4.6.2-ls198"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.11 (2026-06-26)
+
+- Update to upstream v1.17.11
+
 ## 1.17.10 (2026-06-25)
 
 - Update to upstream v1.17.10

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.10"
+version: "1.17.11"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-25",
+  "last_update": "2026-06-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.10"
+  "upstream_version": "v1.17.11"
 }

--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-4.0.18.2978-ls176 (2026-06-26)
+
+- Update to upstream develop-4.0.18.2978-ls176
+
 ## develop-4.0.18.2976-ls175 (2026-06-25)
 
 - Update to upstream develop-4.0.18.2976-ls175

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -82,4 +82,4 @@ schema:
 slug: sonarr
 udev: true
 url: https://sonarr.tv
-version: "develop-4.0.18.2976-ls175"
+version: "develop-4.0.18.2978-ls176"

--- a/sonarr/updater.json
+++ b/sonarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-25",
+  "last_update": "2026-06-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "sonarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-sonarr",
-  "upstream_version": "develop-4.0.18.2976-ls175"
+  "upstream_version": "develop-4.0.18.2978-ls176"
 }


### PR DESCRIPTION
## Upstream version updates

- **haproxy**: `v2.8.24` → `v3.4.1`
- **mastodon**: `v4.6.1-ls198` → `v4.6.2-ls198`
- **opencode**: `v1.17.10` → `v1.17.11`
- **sonarr**: `develop-4.0.18.2976-ls175` → `develop-4.0.18.2978-ls176`


Auto-generated by the daily updater workflow.