### PR TITLE
chore: update upstream versions 2026-06-27

### DIFF
--- a/fail2ban/CHANGELOG.md
+++ b/fail2ban/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-r2-ls37 (2026-06-27)
+
+- Update to upstream 1.1.0-r2-ls37
+
 ## 1.1.0-r2-ls36 (2026-05-19)
 
 - Update to upstream 1.1.0-r2-ls36

--- a/fail2ban/config.yaml
+++ b/fail2ban/config.yaml
@@ -49,4 +49,4 @@ schema:
       path: match(^/.+$)
 slug: fail2ban
 url: https://www.fail2ban.org/
-version: "1.1.0-r2-ls36"
+version: "1.1.0-r2-ls37"

--- a/fail2ban/updater.json
+++ b/fail2ban/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-19",
+  "last_update": "2026-06-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "fail2ban",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-fail2ban",
-  "upstream_version": "1.1.0-r2-ls36"
+  "upstream_version": "1.1.0-r2-ls37"
 }

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.30 (2026-06-27)
+
+- Update to upstream v2.6.30
+
 ## 3.4.1 (2026-06-26)
 
 - Update to upstream v3.4.1

--- a/haproxy/build.json
+++ b/haproxy/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "haproxy:3.4.1-alpine",
-    "amd64": "haproxy:3.4.1-alpine"
+    "aarch64": "haproxy:2.6.30-alpine",
+    "amd64": "haproxy:2.6.30-alpine"
   }
 }

--- a/haproxy/config.yaml
+++ b/haproxy/config.yaml
@@ -31,4 +31,4 @@ slug: haproxy
 startup: application
 boot: auto
 url: https://www.haproxy.org/
-version: "3.4.1"
+version: "2.6.30"

--- a/haproxy/updater.json
+++ b/haproxy/updater.json
@@ -1,6 +1,6 @@
 {
   "dockerhub_tag_filter": "-alpine",
-  "last_update": "2026-06-26",
+  "last_update": "2026-06-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "haproxy",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "library/haproxy",
-  "upstream_version": "v3.4.1"
+  "upstream_version": "v2.6.30"
 }

--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.19.2979-ls316 (2026-06-27)
+
+- Update to upstream 4.0.19.2979-ls316
+
 ## develop-4.0.18.2978-ls176 (2026-06-26)
 
 - Update to upstream develop-4.0.18.2978-ls176

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -82,4 +82,4 @@ schema:
 slug: sonarr
 udev: true
 url: https://sonarr.tv
-version: "develop-4.0.18.2978-ls176"
+version: "4.0.19.2979-ls316"

--- a/sonarr/updater.json
+++ b/sonarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-26",
+  "last_update": "2026-06-27",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "sonarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-sonarr",
-  "upstream_version": "develop-4.0.18.2978-ls176"
+  "upstream_version": "4.0.19.2979-ls316"
 }


### PR DESCRIPTION
## Upstream version updates

- **fail2ban**: `1.1.0-r2-ls36` → `1.1.0-r2-ls37`
- **haproxy**: `v3.4.1` → `v2.6.30`
- **sonarr**: `develop-4.0.18.2978-ls176` → `4.0.19.2979-ls316`


Auto-generated by the daily updater workflow.