### PR TITLE
chore: update upstream versions 2026-06-28

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.17 (2026-06-28)
+
+- Update to upstream v2.63.17
+
 ## 2.63.16 (2026-06-24)
 
 - Update to upstream v2.63.16

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.16-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.16-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.17-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.17-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.16"
+version: "2.63.17"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-24",
+  "last_update": "2026-06-28",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.16"
+  "upstream_version": "v2.63.17"
 }

--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-ls139 (2026-06-28)
+
+- Update to upstream v1.11.2-ls139
+
 ## 1.11.2-ls138 (2026-05-19)
 
 - Update to upstream v1.11.2-ls138

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-ls138"
+version: "1.11.2-ls139"

--- a/pairdrop/updater.json
+++ b/pairdrop/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-05-19",
+  "last_update": "2026-06-28",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "pairdrop",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-pairdrop",
-  "upstream_version": "v1.11.2-ls138"
+  "upstream_version": "v1.11.2-ls139"
 }

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-2.5.0.5422-ls266 (2026-06-28)
+
+- Update to upstream develop-2.5.0.5422-ls266
+
 ## 2.4.0.5397-ls151 (2026-06-24)
 
 - Update to upstream 2.4.0.5397-ls151

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "2.4.0.5397-ls151"
+version: "develop-2.5.0.5422-ls266"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-24",
+  "last_update": "2026-06-28",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "2.4.0.5397-ls151"
+  "upstream_version": "develop-2.5.0.5422-ls266"
 }


### PR DESCRIPTION
## Upstream version updates

- **filebrowser**: `v2.63.16` → `v2.63.17`
- **pairdrop**: `v1.11.2-ls138` → `v1.11.2-ls139`
- **prowlarr**: `2.4.0.5397-ls151` → `develop-2.5.0.5422-ls266`


Auto-generated by the daily updater workflow.