### PR TITLE
chore: update upstream versions 2026-07-01

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.6-ls353 (2026-07-01)
+
+- Update to upstream v1.5.6-ls353
+
 ## 1.5.6-ls352 (2026-06-24)
 
 - Update to upstream v1.5.6-ls352

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "1.5.6-ls352"
+version: "1.5.6-ls353"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-24",
+  "last_update": "2026-07-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "v1.5.6-ls352"
+  "upstream_version": "v1.5.6-ls353"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.12 (2026-07-01)
+
+- Update to upstream v1.17.12
+
 ## 1.17.11 (2026-06-26)
 
 - Update to upstream v1.17.11

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.11"
+version: "1.17.12"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-26",
+  "last_update": "2026-07-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.11"
+  "upstream_version": "v1.17.12"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3-r0-ls352 (2026-07-01)
+
+- Update to upstream 4.1.3-r0-ls352
+
 ## 4.1.2-r0-ls350 (2026-06-24)
 
 - Update to upstream 4.1.2-r0-ls350

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.2-r0-ls350"
+version: "4.1.3-r0-ls352"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-24",
+  "last_update": "2026-07-01",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.2-r0-ls350"
+  "upstream_version": "4.1.3-r0-ls352"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `v1.5.6-ls352` → `v1.5.6-ls353`
- **opencode**: `v1.17.11` → `v1.17.12`
- **transmission**: `4.1.2-r0-ls350` → `4.1.3-r0-ls352`


Auto-generated by the daily updater workflow.