### PR TITLE
chore: update upstream versions 2026-07-02

### DIFF
--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.13 (2026-07-02)
+
+- Update to upstream v1.17.13
+
 ## 1.17.12 (2026-07-01)
 
 - Update to upstream v1.17.12

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.12"
+version: "1.17.13"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-01",
+  "last_update": "2026-07-02",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.12"
+  "upstream_version": "v1.17.13"
 }

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0.5397-ls152 (2026-07-02)
+
+- Update to upstream 2.4.0.5397-ls152
+
 ## develop-2.5.0.5422-ls266 (2026-06-28)
 
 - Update to upstream develop-2.5.0.5422-ls266

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "develop-2.5.0.5422-ls266"
+version: "2.4.0.5397-ls152"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-28",
+  "last_update": "2026-07-02",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "develop-2.5.0.5422-ls266"
+  "upstream_version": "2.4.0.5397-ls152"
 }


### PR DESCRIPTION
## Upstream version updates

- **opencode**: `v1.17.12` → `v1.17.13`
- **prowlarr**: `develop-2.5.0.5422-ls266` → `2.4.0.5397-ls152`


Auto-generated by the daily updater workflow.