### PR TITLE
chore: update upstream versions 2026-07-03

### DIFF
--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.2-ls199 (2026-07-03)
+
+- Update to upstream v4.6.2-ls199
+
 ## 4.6.2-ls198 (2026-06-26)
 
 - Update to upstream v4.6.2-ls198

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.6.2-ls198"
+version: "4.6.2-ls199"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-06-26",
+  "last_update": "2026-07-03",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.6.2-ls198"
+  "upstream_version": "v4.6.2-ls199"
 }


### PR DESCRIPTION
## Upstream version updates

- **mastodon**: `v4.6.2-ls198` → `v4.6.2-ls199`


Auto-generated by the daily updater workflow.