### PR TITLE
chore: update upstream versions 2026-07-05

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0-ls354 (2026-07-05)
+
+- Update to upstream v1.6.0-ls354
+
 ## 1.5.6-ls353 (2026-07-01)
 
 - Update to upstream v1.5.6-ls353

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "1.5.6-ls353"
+version: "1.6.0-ls354"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-01",
+  "last_update": "2026-07-05",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "v1.5.6-ls353"
+  "upstream_version": "v1.6.0-ls354"
 }

--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.18 (2026-07-05)
+
+- Update to upstream v2.63.18
+
 ## 2.63.17 (2026-06-28)
 
 - Update to upstream v2.63.17

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.17-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.17-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.18-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.18-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.17"
+version: "2.63.18"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-06-28",
+  "last_update": "2026-07-05",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.17"
+  "upstream_version": "v2.63.18"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `v1.5.6-ls353` → `v1.6.0-ls354`
- **filebrowser**: `v2.63.17` → `v2.63.18`


Auto-generated by the daily updater workflow.