### PR TITLE
chore: update upstream versions 2026-07-14

### DIFF
--- a/lightrag/CHANGELOG.md
+++ b/lightrag/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.5rc1 (2026-07-14)
+
+- Update to upstream v1.5.5rc1
+
 ## 1.5.4 (2026-06-25)
 
 - Update to upstream v1.5.4

--- a/lightrag/build.json
+++ b/lightrag/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.4",
-    "amd64": "ghcr.io/hkuds/lightrag:v1.5.4"
+    "aarch64": "ghcr.io/hkuds/lightrag:v1.5.5rc1",
+    "amd64": "ghcr.io/hkuds/lightrag:v1.5.5rc1"
   }
 }

--- a/lightrag/config.yaml
+++ b/lightrag/config.yaml
@@ -68,4 +68,4 @@ schema:
       value: str?
 slug: lightrag
 url: https://github.com/HKUDS/LightRAG
-version: "1.5.4"
+version: "1.5.5rc1"

--- a/lightrag/updater.json
+++ b/lightrag/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-06-25",
+  "last_update": "2026-07-14",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "lightrag",
@@ -7,5 +7,5 @@
   "tag_keep_v": true,
   "tag_strategy": "direct",
   "upstream_repo": "HKUDS/LightRAG",
-  "upstream_version": "v1.5.4"
+  "upstream_version": "v1.5.5rc1"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.20 (2026-07-14)
+
+- Update to upstream v1.17.20
+
 ## 1.17.18 (2026-07-10)
 
 - Update to upstream v1.17.18

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.18"
+version: "1.17.20"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-10",
+  "last_update": "2026-07-14",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.18"
+  "upstream_version": "v1.17.20"
 }


### PR DESCRIPTION
## Upstream version updates

- **lightrag**: `v1.5.4` → `v1.5.5rc1`
- **opencode**: `v1.17.18` → `v1.17.20`


Auto-generated by the daily updater workflow.