### PR TITLE
chore: update upstream versions 2026-07-15

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0-ls355 (2026-07-15)
+
+- Update to upstream v1.6.0-ls355
+
 ## development-v1.6.0-ls800 (2026-07-08)
 
 - Update to upstream development-v1.6.0-ls800

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "development-v1.6.0-ls800"
+version: "1.6.0-ls355"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-08",
+  "last_update": "2026-07-15",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "development-v1.6.0-ls800"
+  "upstream_version": "v1.6.0-ls355"
 }

--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## glitch-v4.6.3-ls340 (2026-07-15)
+
+- Update to upstream glitch-v4.6.3-ls340
+
 ## 4.6.3-ls200 (2026-07-04)
 
 - Update to upstream v4.6.3-ls200

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.6.3-ls200"
+version: "glitch-v4.6.3-ls340"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-04",
+  "last_update": "2026-07-15",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.6.3-ls200"
+  "upstream_version": "glitch-v4.6.3-ls340"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.1 (2026-07-15)
+
+- Update to upstream v1.18.1
+
 ## 1.17.20 (2026-07-14)
 
 - Update to upstream v1.17.20

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.17.20"
+version: "1.18.1"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-14",
+  "last_update": "2026-07-15",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.17.20"
+  "upstream_version": "v1.18.1"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3-r0-ls354 (2026-07-15)
+
+- Update to upstream 4.1.3-r0-ls354
+
 ## 4.1.3-r0-ls353 (2026-07-08)
 
 - Update to upstream 4.1.3-r0-ls353

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.3-r0-ls353"
+version: "4.1.3-r0-ls354"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-08",
+  "last_update": "2026-07-15",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.3-r0-ls353"
+  "upstream_version": "4.1.3-r0-ls354"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `development-v1.6.0-ls800` → `v1.6.0-ls355`
- **mastodon**: `v4.6.3-ls200` → `glitch-v4.6.3-ls340`
- **opencode**: `v1.17.20` → `v1.18.1`
- **transmission**: `4.1.3-r0-ls353` → `4.1.3-r0-ls354`


Auto-generated by the daily updater workflow.