### PR TITLE
chore: update upstream versions 2026-07-16

### DIFF
--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.3-ls201 (2026-07-16)
+
+- Update to upstream v4.6.3-ls201
+
 ## glitch-v4.6.3-ls340 (2026-07-15)
 
 - Update to upstream glitch-v4.6.3-ls340

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "glitch-v4.6.3-ls340"
+version: "4.6.3-ls201"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-15",
+  "last_update": "2026-07-16",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "glitch-v4.6.3-ls340"
+  "upstream_version": "v4.6.3-ls201"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.2 (2026-07-16)
+
+- Update to upstream v1.18.2
+
 ## 1.18.1 (2026-07-15)
 
 - Update to upstream v1.18.1

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.18.1"
+version: "1.18.2"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-15",
+  "last_update": "2026-07-16",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.18.1"
+  "upstream_version": "v1.18.2"
 }

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0.5397-ls154 (2026-07-16)
+
+- Update to upstream 2.4.0.5397-ls154
+
 ## develop-2.5.1.5464-ls268 (2026-07-13)
 
 - Update to upstream develop-2.5.1.5464-ls268

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "develop-2.5.1.5464-ls268"
+version: "2.4.0.5397-ls154"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-13",
+  "last_update": "2026-07-16",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "develop-2.5.1.5464-ls268"
+  "upstream_version": "2.4.0.5397-ls154"
 }


### PR DESCRIPTION
## Upstream version updates

- **mastodon**: `glitch-v4.6.3-ls340` → `v4.6.3-ls201`
- **opencode**: `v1.18.1` → `v1.18.2`
- **prowlarr**: `develop-2.5.1.5464-ls268` → `2.4.0.5397-ls154`


Auto-generated by the daily updater workflow.