### PR TITLE
chore: update upstream versions 2026-07-19

### DIFF
--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-ls141 (2026-07-19)
+
+- Update to upstream v1.11.2-ls141
+
 ## 1.11.2-ls140 (2026-07-12)
 
 - Update to upstream v1.11.2-ls140

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-ls140"
+version: "1.11.2-ls141"

--- a/pairdrop/updater.json
+++ b/pairdrop/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-12",
+  "last_update": "2026-07-19",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "pairdrop",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-pairdrop",
-  "upstream_version": "v1.11.2-ls140"
+  "upstream_version": "v1.11.2-ls141"
 }


### PR DESCRIPTION
## Upstream version updates

- **pairdrop**: `v1.11.2-ls140` → `v1.11.2-ls141`


Auto-generated by the daily updater workflow.