### PR TITLE
chore: update upstream versions 2026-07-21

### DIFF
--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.4 (2026-07-21)
+
+- Update to upstream v1.18.4
+
 ## 1.18.3 (2026-07-17)
 
 - Update to upstream v1.18.3

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.18.3"
+version: "1.18.4"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-17",
+  "last_update": "2026-07-21",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.18.3"
+  "upstream_version": "v1.18.4"
 }


### PR DESCRIPTION
## Upstream version updates

- **opencode**: `v1.18.3` → `v1.18.4`


Auto-generated by the daily updater workflow.