### PR TITLE
chore: update upstream versions 2026-07-22

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0-ls356 (2026-07-22)
+
+- Update to upstream v1.6.0-ls356
+
 ## 1.6.0-ls355 (2026-07-15)
 
 - Update to upstream v1.6.0-ls355

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -73,4 +73,4 @@ schema:
 slug: bazarr
 udev: true
 url: https://www.bazarr.media
-version: "1.6.0-ls355"
+version: "1.6.0-ls356"

--- a/bazarr/updater.json
+++ b/bazarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-15",
+  "last_update": "2026-07-22",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "bazarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-bazarr",
-  "upstream_version": "v1.6.0-ls355"
+  "upstream_version": "v1.6.0-ls356"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## pr-38252-videos (2026-07-22)
+
+- Update to upstream pr-38252-videos
+
 ## 1.18.4 (2026-07-21)
 
 - Update to upstream v1.18.4

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "1.18.4"
+version: "pr-38252-videos"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-21",
+  "last_update": "2026-07-22",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "v1.18.4"
+  "upstream_version": "pr-38252-videos"
 }

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3-r0-ls355 (2026-07-22)
+
+- Update to upstream 4.1.3-r0-ls355
+
 ## 4.1.3-r0-ls354 (2026-07-15)
 
 - Update to upstream 4.1.3-r0-ls354

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: transmission
 udev: true
 url: https://transmissionbt.com
-version: "4.1.3-r0-ls354"
+version: "4.1.3-r0-ls355"

--- a/transmission/updater.json
+++ b/transmission/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-15",
+  "last_update": "2026-07-22",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "transmission",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-transmission",
-  "upstream_version": "4.1.3-r0-ls354"
+  "upstream_version": "4.1.3-r0-ls355"
 }

--- a/valkey/CHANGELOG.md
+++ b/valkey/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.1 (2026-07-22)
+
+- Update to upstream 9.1.1
+
 ## 9.1.0 (2026-05-24)
 
 - Update to upstream 9.1.0

--- a/valkey/build.json
+++ b/valkey/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "valkey/valkey:9.1.0-alpine",
-    "amd64": "valkey/valkey:9.1.0-alpine"
+    "aarch64": "valkey/valkey:9.1.1-alpine",
+    "amd64": "valkey/valkey:9.1.1-alpine"
   }
 }

--- a/valkey/config.yaml
+++ b/valkey/config.yaml
@@ -40,4 +40,4 @@ schema:
       value: str?
 slug: valkey
 url: https://valkey.io
-version: "9.1.0"
+version: "9.1.1"

--- a/valkey/updater.json
+++ b/valkey/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-05-24",
+  "last_update": "2026-07-22",
   "major_version": "9",
   "paused": false,
   "slug": "valkey",
@@ -7,5 +7,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "valkey-io/valkey",
-  "upstream_version": "9.1.0"
+  "upstream_version": "9.1.1"
 }

--- a/valkey8/CHANGELOG.md
+++ b/valkey8/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.9 (2026-07-22)
+
+- Update to upstream 8.1.9
+
 ## 8.1.8 (2026-06-03)
 
 - Update to upstream 8.1.8

--- a/valkey8/build.json
+++ b/valkey8/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "valkey/valkey:8.1.8-alpine",
-    "amd64": "valkey/valkey:8.1.8-alpine"
+    "aarch64": "valkey/valkey:8.1.9-alpine",
+    "amd64": "valkey/valkey:8.1.9-alpine"
   }
 }

--- a/valkey8/config.yaml
+++ b/valkey8/config.yaml
@@ -40,4 +40,4 @@ schema:
       value: str?
 slug: valkey8
 url: https://valkey.io
-version: "8.1.8"
+version: "8.1.9"

--- a/valkey8/updater.json
+++ b/valkey8/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "2026-06-03",
+  "last_update": "2026-07-22",
   "major_version": "8",
   "paused": false,
   "slug": "valkey8",
@@ -7,5 +7,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-alpine",
   "upstream_repo": "valkey-io/valkey",
-  "upstream_version": "8.1.8"
+  "upstream_version": "8.1.9"
 }


### PR DESCRIPTION
## Upstream version updates

- **bazarr**: `v1.6.0-ls355` → `v1.6.0-ls356`
- **opencode**: `v1.18.4` → `pr-38252-videos`
- **transmission**: `4.1.3-r0-ls354` → `4.1.3-r0-ls355`
- **valkey**: `9.1.0` → `9.1.1`
- **valkey8**: `8.1.8` → `8.1.9`


Auto-generated by the daily updater workflow.