### PR TITLE
chore: update upstream versions 2026-07-23

### DIFF
--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.2.5491-ls155 (2026-07-23)
+
+- Update to upstream 2.5.2.5491-ls155
+
 ## develop-2.5.2.5483-ls269 (2026-07-20)
 
 - Update to upstream develop-2.5.2.5483-ls269

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -72,4 +72,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://prowlarr.com
-version: "develop-2.5.2.5483-ls269"
+version: "2.5.2.5491-ls155"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-20",
+  "last_update": "2026-07-23",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "develop-2.5.2.5483-ls269"
+  "upstream_version": "2.5.2.5491-ls155"
 }


### PR DESCRIPTION
## Upstream version updates

- **prowlarr**: `develop-2.5.2.5483-ls269` → `2.5.2.5491-ls155`


Auto-generated by the daily updater workflow.