### PR TITLE
chore: update upstream versions 2026-07-24

### DIFF
--- a/mastodon/CHANGELOG.md
+++ b/mastodon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.3-ls202 (2026-07-24)
+
+- Update to upstream v4.6.3-ls202
+
 ## 4.6.3-ls201 (2026-07-16)
 
 - Update to upstream v4.6.3-ls201

--- a/mastodon/config.yaml
+++ b/mastodon/config.yaml
@@ -87,4 +87,4 @@ schema:
   ES_ENABLED: bool
 slug: mastodon
 url: https://joinmastodon.org
-version: "4.6.3-ls201"
+version: "4.6.3-ls202"

--- a/mastodon/updater.json
+++ b/mastodon/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-16",
+  "last_update": "2026-07-24",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "mastodon",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-mastodon",
-  "upstream_version": "v4.6.3-ls201"
+  "upstream_version": "v4.6.3-ls202"
 }


### PR DESCRIPTION
## Upstream version updates

- **mastodon**: `v4.6.3-ls201` → `v4.6.3-ls202`


Auto-generated by the daily updater workflow.