### PR TITLE
chore: update upstream versions 2026-07-25

### DIFF
--- a/fail2ban/CHANGELOG.md
+++ b/fail2ban/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-r2-ls40 (2026-07-25)
+
+- Update to upstream 1.1.0-r2-ls40
+
 ## 1.1.0-r2-ls39 (2026-07-18)
 
 - Update to upstream 1.1.0-r2-ls39

--- a/fail2ban/config.yaml
+++ b/fail2ban/config.yaml
@@ -49,4 +49,4 @@ schema:
       path: match(^/.+$)
 slug: fail2ban
 url: https://www.fail2ban.org/
-version: "1.1.0-r2-ls39"
+version: "1.1.0-r2-ls40"

--- a/fail2ban/updater.json
+++ b/fail2ban/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-18",
+  "last_update": "2026-07-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "fail2ban",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-fail2ban",
-  "upstream_version": "1.1.0-r2-ls39"
+  "upstream_version": "1.1.0-r2-ls40"
 }

--- a/opencode/CHANGELOG.md
+++ b/opencode/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.5 (2026-07-25)
+
+- Update to upstream v1.18.5
+
 ## pr-38252-videos (2026-07-22)
 
 - Update to upstream pr-38252-videos

--- a/opencode/config.yaml
+++ b/opencode/config.yaml
@@ -60,4 +60,4 @@ schema:
   workspace: str
 slug: opencode
 url: https://github.com/anomalyco/opencode
-version: "pr-38252-videos"
+version: "1.18.5"

--- a/opencode/updater.json
+++ b/opencode/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-22",
+  "last_update": "2026-07-25",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "opencode",
   "source": "github",
   "tag_strategy": "dockerfile",
   "upstream_repo": "anomalyco/opencode",
-  "upstream_version": "pr-38252-videos"
+  "upstream_version": "v1.18.5"
 }


### PR DESCRIPTION
## Upstream version updates

- **fail2ban**: `1.1.0-r2-ls39` → `1.1.0-r2-ls40`
- **opencode**: `pr-38252-videos` → `v1.18.5`


Auto-generated by the daily updater workflow.