### PR TITLE
chore: update upstream versions 2026-07-26

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.63.20 (2026-07-26)
+
+- Update to upstream v2.63.20
+
 ## 2.63.18 (2026-07-05)
 
 - Update to upstream v2.63.18

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "filebrowser/filebrowser:v2.63.18-s6",
-    "amd64": "filebrowser/filebrowser:v2.63.18-s6"
+    "aarch64": "filebrowser/filebrowser:v2.63.20-s6",
+    "amd64": "filebrowser/filebrowser:v2.63.20-s6"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -78,4 +78,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://filebrowser.org
-version: "2.63.18"
+version: "2.63.20"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": false,
-  "last_update": "2026-07-05",
+  "last_update": "2026-07-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "filebrowser",
@@ -9,5 +9,5 @@
   "tag_strategy": "suffix",
   "tag_suffix": "-s6",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "v2.63.18"
+  "upstream_version": "v2.63.20"
 }

--- a/pairdrop/CHANGELOG.md
+++ b/pairdrop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-ls142 (2026-07-26)
+
+- Update to upstream v1.11.2-ls142
+
 ## 1.11.2-ls141 (2026-07-19)
 
 - Update to upstream v1.11.2-ls141

--- a/pairdrop/config.yaml
+++ b/pairdrop/config.yaml
@@ -77,4 +77,4 @@ schema:
 slug: pairdrop
 udev: true
 url: https://github.com/schlagmichdoch/PairDrop
-version: "1.11.2-ls141"
+version: "1.11.2-ls142"

--- a/pairdrop/updater.json
+++ b/pairdrop/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-19",
+  "last_update": "2026-07-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "pairdrop",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-pairdrop",
-  "upstream_version": "v1.11.2-ls141"
+  "upstream_version": "v1.11.2-ls142"
 }

--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## develop-4.0.19.2991-ls181 (2026-07-26)
+
+- Update to upstream develop-4.0.19.2991-ls181
+
 ## 4.0.19.2979-ls320 (2026-07-18)
 
 - Update to upstream 4.0.19.2979-ls320

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -82,4 +82,4 @@ schema:
 slug: sonarr
 udev: true
 url: https://sonarr.tv
-version: "4.0.19.2979-ls320"
+version: "develop-4.0.19.2991-ls181"

--- a/sonarr/updater.json
+++ b/sonarr/updater.json
@@ -1,10 +1,10 @@
 {
-  "last_update": "2026-07-18",
+  "last_update": "2026-07-26",
   "paused": false,
   "repository": "rezusnet/hassio-addons",
   "slug": "sonarr",
   "source": "github",
   "tag_strategy": "lsio-latest",
   "upstream_repo": "linuxserver/docker-sonarr",
-  "upstream_version": "4.0.19.2979-ls320"
+  "upstream_version": "develop-4.0.19.2991-ls181"
 }


### PR DESCRIPTION
## Upstream version updates

- **filebrowser**: `v2.63.18` → `v2.63.20`
- **pairdrop**: `v1.11.2-ls141` → `v1.11.2-ls142`
- **sonarr**: `4.0.19.2979-ls320` → `develop-4.0.19.2991-ls181`


Auto-generated by the daily updater workflow.